### PR TITLE
Support for CI using github-actions

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -8,15 +8,14 @@ on:
       - dev
 
 jobs:
-  build:
+  build-gcc:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04, ubuntu-latest]
         build-type: [Release, Debug]
-        compiler: [g++, clang++]
 
-    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • ${{matrix.compiler}}"
+    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • GCC"
     runs-on: ${{matrix.os}}
 
     steps:
@@ -27,8 +26,33 @@ jobs:
 
     - name: Configure CMake
       env:
-        CC: ${{matrix.compiler}}
-        CXX: ${{matrix.compiler}}
+        CC: gcc
+        CXX: g++
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+
+    - name: Build C++ Project
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
+
+  build-clang:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-latest]
+        build-type: [Release, Debug]
+
+    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • Clang"
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.10
+
+    - name: Configure CMake
+      env:
+        CC: clang
+        CXX: clang++
       run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
 
     - name: Build C++ Project

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Build C++ Project
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
 
+    - name: Running C++ Tests
+      run: ctest --test-dir ${{github.workspace}}/build/tests/cpp
+
   build-clang:
     strategy:
       fail-fast: false
@@ -57,3 +60,6 @@ jobs:
 
     - name: Build C++ Project
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
+
+    - name: Running C++ Tests
+      run: ctest --test-dir ${{github.workspace}}/build/tests/cpp

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,0 +1,35 @@
+name: ci-linux
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - dev
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        build-type: [Release, Debug]
+        compiler: [g++, clang++]
+
+    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • ${{matrix.compiler}}"
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.10
+
+    - name: Configure CMake
+      env:
+        CC: ${{matrix.compiler}}
+        CXX: ${{matrix.compiler}}
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+
+    - name: Build C++ Project
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -29,3 +29,6 @@ jobs:
 
     - name: Build C++ Project
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
+
+    - name: Running C++ Tests
+      run: ctest --test-dir ${{github.workspace}}/build/tests/cpp

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,0 +1,31 @@
+name: ci-macos
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - dev
+
+jobs:
+  build-gcc:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+        build-type: [Release, Debug]
+
+    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • Apple Clang"
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.10
+
+    - name: Configure CMake
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+
+    - name: Build C++ Project
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,3 +31,6 @@ jobs:
 
     - name: Build C++ Project
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
+
+    - name: Running C++ Tests
+      run: ctest --test-dir ${{github.workspace}}/build/tests/cpp

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,59 @@
+name: ci-windows
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+      - dev
+
+jobs:
+  build-msvc:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build-type: [Release, Debug]
+
+    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • MSVC"
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.10
+
+    - name: Configure CMake
+      env:
+        CMAKE_GENERATOR: "Visual Studio 16 2019"
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+
+    - name: Build C++ Project
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
+
+  build-clang:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build-type: [Release, Debug]
+
+    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • Clang"
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.10
+
+    - name: Configure CMake
+      env:
+        CC: clang
+        CXX: clang++
+        CMAKE_GENERATOR: Ninja
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+
+    - name: Build C++ Project
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -50,8 +50,6 @@ jobs:
 
     - name: Configure CMake
       env:
-        CC: clang
-        CXX: clang++
         CMAKE_GENERATOR: Ninja
       run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -31,27 +31,3 @@ jobs:
 
     - name: Build C++ Project
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
-
-  build-clang:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest]
-        build-type: [Release, Debug]
-
-    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • Clang"
-    runs-on: ${{matrix.os}}
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Update CMake
-      uses: jwlawson/actions-setup-cmake@v1.10
-
-    - name: Configure CMake
-      env:
-        CMAKE_GENERATOR: Ninja
-      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
-
-    - name: Build C++ Project
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ target_include_directories(TinyMathCpp
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 # Make sure that we don't re-define the make_unique if it's already exposed
 if(MSVC)
-  target_compile_options(TinyUtilsCpp PUBLIC "/Zc:__cplusplus")
+  target_compile_options(TinyMathCpp PUBLIC "/Zc:__cplusplus")
+  target_compile_options(TinyMathCpp PUBLIC "/permissive-")
 endif()
 
 if(TINYMATH_BUILD_SSE)

--- a/include/tinymath/vec3_t.hpp
+++ b/include/tinymath/vec3_t.hpp
@@ -81,28 +81,30 @@ auto operator*(const Vector3<Scalar_T>& vec, Scalar_T scale)
     -> Vector3<Scalar_T>;
 
 template <typename Scalar_T>
-auto operator<<(std::ostream& stdout, const Vector3<Scalar_T>& src)
+auto operator<<(std::ostream& output_stream, const Vector3<Scalar_T>& src)
     -> std::ostream& {
-    stdout << "(" << src.x() << ", " << src.y() << ", " << src.z() << ")";
-    return stdout;
+    output_stream << "(" << src.x() << ", " << src.y() << ", " << src.z()
+                  << ")";
+    return output_stream;
 }
 
 template <typename Scalar_T>
-auto operator>>(std::istream& stdin, Vector3<Scalar_T>& dst) -> std::istream& {
+auto operator>>(std::istream& input_stream, Vector3<Scalar_T>& dst)
+    -> std::istream& {
     // Based on ignition-math implementation https://bit.ly/3iqAVgS
     Scalar_T x{};
     Scalar_T y{};
     Scalar_T z{};
 
-    stdin.setf(std::ios_base::skipws);
-    stdin >> x >> y >> z;
-    if (!stdin.fail()) {
+    input_stream.setf(std::ios_base::skipws);
+    input_stream >> x >> y >> z;
+    if (!input_stream.fail()) {
         dst.x() = x;
         dst.y() = y;
         dst.z() = z;
     }
 
-    return stdin;
+    return input_stream;
 }
 
 template <typename Scalar_T>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,9 @@
 setuptools
-ninja
 pytest
 pylint
 black
-cmake>=3.15
 cmakelang[YAML]==v0.6.13
 pre-commit==v2.14.0
+cpplint
 ipython
 ipykernel


### PR DESCRIPTION
## Description
This PR keeps track of the CI feature required for the project. We'll make use of github-actions mostly, but will likely use docker-images to test in other operating systems variants (e.g. Arch-based, Fedora, etc.)

### Requirements
- [x] Support for CI on `ubuntu-latest` with combinations of compilers and build-types
- [x] Support for CI on `windows-latest` with combinations of compilers and build-types
- [x] Support for CI on 'macos-latest` widh combinations of compilers and build-types
- [x] Integrate unittests into the workflow
- [x] ~Run formatting, linting, and sanitizers~ (**will first add support for sanitizers locally**)