### PR TITLE
Vector-3 operations

### DIFF
--- a/include/tinymath/impl/vec3_t_avx_impl.hpp
+++ b/include/tinymath/impl/vec3_t_avx_impl.hpp
@@ -8,15 +8,20 @@ namespace tiny {
 namespace math {
 namespace avx {
 
-// NOLINTNEXTLINE(runtime/references)
-auto kernel_add(Vector3<float64_t>::BufferType& dst,
-                const Vector3<float64_t>::BufferType& lhs,
-                const Vector3<float64_t>::BufferType& rhs) -> void;  // NOLINT
+// ***************************************************************************//
+//    Declarations for double-precision floating point numbers (float64_t)    //
+// ***************************************************************************//
+using Vec3d = Vector3<float64_t>;
+using Array3d = Vec3d::BufferType;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_sub(Vector3<float64_t>::BufferType& dst,
-                const Vector3<float64_t>::BufferType& lhs,
-                const Vector3<float64_t>::BufferType& rhs) -> void;  // NOLINT
+auto kernel_add(Array3d& dst, const Array3d& lhs, const Array3d& rhs) -> void;
+
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_sub(Array3d& dst, const Array3d& lhs, const Array3d& rhs) -> void;
+
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_scale(Array3d& dst, float64_t scale, const Array3d& vec) -> void;
 
 }  // namespace avx
 }  // namespace math

--- a/include/tinymath/impl/vec3_t_scalar_impl.hpp
+++ b/include/tinymath/impl/vec3_t_scalar_impl.hpp
@@ -21,6 +21,8 @@ auto kernel_sub(Array3f& dst, const Array3f& lhs, const Array3f& rhs) -> void;
 // NOLINTNEXTLINE(runtime/references)
 auto kernel_scale(Array3f& dst, float32_t scale, const Array3f& vec) -> void;
 
+auto kernel_length_square(const Array3f& vec) -> float32_t;
+
 // ***************************************************************************//
 //    Declarations for double-precision floating point numbers (float64_t)    //
 // ***************************************************************************//
@@ -35,6 +37,8 @@ auto kernel_sub(Array3d& dst, const Array3d& lhs, const Array3d& rhs) -> void;
 
 // NOLINTNEXTLINE(runtime/references)
 auto kernel_scale(Array3d& dst, float64_t scale, const Array3d& vec) -> void;
+
+auto kernel_length_square(const Array3d& vec) -> float64_t;
 
 }  // namespace scalar
 }  // namespace math

--- a/include/tinymath/impl/vec3_t_scalar_impl.hpp
+++ b/include/tinymath/impl/vec3_t_scalar_impl.hpp
@@ -6,27 +6,35 @@ namespace tiny {
 namespace math {
 namespace scalar {
 
-// Kernels for single-precision types (float32_t)
+// ***************************************************************************//
+//    Declarations for single-precision floating point numbers (float32_t)    //
+// ***************************************************************************//
 using Vec3f = Vector3<float32_t>;
+using Array3f = Vec3f::BufferType;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_add(Vec3f::BufferType& dst, const Vec3f::BufferType& lhs,
-                const Vec3f::BufferType& rhs) -> void;  // NOLINT
+auto kernel_add(Array3f& dst, const Array3f& lhs, const Array3f& rhs) -> void;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_sub(Vec3f::BufferType& dst, const Vec3f::BufferType& lhs,
-                const Vec3f::BufferType& rhs) -> void;  // NOLINT
+auto kernel_sub(Array3f& dst, const Array3f& lhs, const Array3f& rhs) -> void;
 
-// Kernels for double-precision types (float64_t)
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_scale(Array3f& dst, float32_t scale, const Array3f& vec) -> void;
+
+// ***************************************************************************//
+//    Declarations for double-precision floating point numbers (float64_t)    //
+// ***************************************************************************//
 using Vec3d = Vector3<float64_t>;
+using Array3d = Vec3d::BufferType;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_add(Vec3d::BufferType& dst, const Vec3d::BufferType& lhs,
-                const Vec3d::BufferType& rhs) -> void;  // NOLINT
+auto kernel_add(Array3d& dst, const Array3d& lhs, const Array3d& rhs) -> void;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_sub(Vec3d::BufferType& dst, const Vec3d::BufferType& lhs,
-                const Vec3d::BufferType& rhs) -> void;  // NOLINT
+auto kernel_sub(Array3d& dst, const Array3d& lhs, const Array3d& rhs) -> void;
+
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_scale(Array3d& dst, float64_t scale, const Array3d& vec) -> void;
 
 }  // namespace scalar
 }  // namespace math

--- a/include/tinymath/impl/vec3_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec3_t_sse_impl.hpp
@@ -8,15 +8,20 @@ namespace tiny {
 namespace math {
 namespace sse {
 
-// NOLINTNEXTLINE(runtime/references)
-auto kernel_add(Vector3<float32_t>::BufferType& dst,
-                const Vector3<float32_t>::BufferType& lhs,
-                const Vector3<float32_t>::BufferType& rhs) -> void;  // NOLINT
+// ***************************************************************************//
+//    Declarations for single-precision floating point numbers (float32_t)    //
+// ***************************************************************************//
+using Vec3f = Vector3<float32_t>;
+using Array3f = Vec3f::BufferType;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_sub(Vector3<float32_t>::BufferType& dst,
-                const Vector3<float32_t>::BufferType& lhs,
-                const Vector3<float32_t>::BufferType& rhs) -> void;  // NOLINT
+auto kernel_add(Array3f& dst, const Array3f& lhs, const Array3f& rhs) -> void;
+
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_sub(Array3f& dst, const Array3f& lhs, const Array3f& rhs) -> void;
+
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_scale(Array3f& dst, float32_t scale, const Array3f& vec) -> void;
 
 }  // namespace sse
 }  // namespace math

--- a/include/tinymath/vec3_t.hpp
+++ b/include/tinymath/vec3_t.hpp
@@ -51,6 +51,18 @@ class Vector3 {
         return m_Elements[index];
     }
 
+    // @todo(wilbert): implement square_length (PR: #3)
+    auto length_square() const -> Scalar_T;
+
+    // @todo(wilbert): implement length (PR: #3)
+    auto length() const -> Scalar_T;
+
+    // @todo(wilbert): implement inner product (PR: #3)
+    auto dot() const -> Scalar_T;
+
+    // @todo(wilbert): implement cross product (PR: #3)
+    auto cross() const -> Vector3<Scalar_T>;
+
     auto toString() const -> std::string;
 
     constexpr auto ndim() const -> uint32_t { return VECTOR_NDIM; }
@@ -78,6 +90,11 @@ auto operator*(Scalar_T scale, const Vector3<Scalar_T>& vec)
 
 template <typename Scalar_T>
 auto operator*(const Vector3<Scalar_T>& vec, Scalar_T scale)
+    -> Vector3<Scalar_T>;
+
+// @todo(wilbert): implement Hadamard-Schur product (PR: #3)
+template <typename Scalar_T>
+auto operator*(const Vector3<Scalar_T>& v1, const Vector3<Scalar_T>& v2)
     -> Vector3<Scalar_T>;
 
 template <typename Scalar_T>

--- a/src/tinymath/impl/vec3_t_avx_impl.cpp
+++ b/src/tinymath/impl/vec3_t_avx_impl.cpp
@@ -11,25 +11,31 @@ namespace avx {
 // ***************************************************************************//
 //   Implementations for double-precision floating point numbers (float64_t)  //
 // ***************************************************************************//
+using Vec3d = Vector3<float64_t>;
+using Array3d = Vec3d::BufferType;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_add(Vector3<float64_t>::BufferType& dst,
-                const Vector3<float64_t>::BufferType& lhs,
-                const Vector3<float64_t>::BufferType& rhs) -> void {  // NOLINT
-    auto ymm_lhs = _mm256_load_pd(lhs.data());
-    auto ymm_rhs = _mm256_load_pd(rhs.data());
+auto kernel_add(Array3d& dst, const Array3d& lhs, const Array3d& rhs) -> void {
+    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
+    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
     auto ymm_result = _mm256_add_pd(ymm_lhs, ymm_rhs);
-    _mm256_store_pd(dst.data(), ymm_result);
+    _mm256_storeu_pd(dst.data(), ymm_result);
 }
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_sub(Vector3<float64_t>::BufferType& dst,
-                const Vector3<float64_t>::BufferType& lhs,
-                const Vector3<float64_t>::BufferType& rhs) -> void {  // NOLINT
-    auto ymm_lhs = _mm256_load_pd(lhs.data());
-    auto ymm_rhs = _mm256_load_pd(rhs.data());
+auto kernel_sub(Array3d& dst, const Array3d& lhs, const Array3d& rhs) -> void {
+    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
+    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
     auto ymm_result = _mm256_sub_pd(ymm_lhs, ymm_rhs);
-    _mm256_store_pd(dst.data(), ymm_result);
+    _mm256_storeu_pd(dst.data(), ymm_result);
+}
+
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_scale(Array3d& dst, float64_t scale, const Array3d& vec) -> void {
+    auto ymm_scale = _mm256_set1_pd(scale);
+    auto ymm_vector = _mm256_loadu_pd(vec.data());
+    auto ymm_result = _mm256_mul_pd(ymm_scale, ymm_vector);
+    _mm256_storeu_pd(dst.data(), ymm_result);
 }
 
 }  // namespace avx

--- a/src/tinymath/impl/vec3_t_scalar_impl.cpp
+++ b/src/tinymath/impl/vec3_t_scalar_impl.cpp
@@ -31,6 +31,10 @@ auto kernel_scale(Array3f& dst, float32_t scale, const Array3f& vec) -> void {
     }
 }
 
+auto kernel_length_square(const Array3f& vec) -> float32_t {
+    return vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2];
+}
+
 // ***************************************************************************//
 //   Implementations for double-precision floating point numbers (float64_t)  //
 // ***************************************************************************//
@@ -56,6 +60,10 @@ auto kernel_scale(Array3d& dst, float64_t scale, const Array3d& vec) -> void {
     for (uint32_t i = 0; i < Vec3d::VECTOR_NDIM; ++i) {
         dst[i] = scale * vec[i];
     }
+}
+
+auto kernel_length_square(const Array3d& vec) -> float64_t {
+    return vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2];
 }
 
 }  // namespace scalar

--- a/src/tinymath/impl/vec3_t_scalar_impl.cpp
+++ b/src/tinymath/impl/vec3_t_scalar_impl.cpp
@@ -7,44 +7,54 @@ namespace scalar {
 // ***************************************************************************//
 //   Implementations for single-precision floating point numbers (float32_t)  //
 // ***************************************************************************//
+using Vec3f = Vector3<float32_t>;
+using Array3f = Vec3f::BufferType;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_add(Vector3<float32_t>::BufferType& dst,
-                const Vector3<float32_t>::BufferType& lhs,
-                const Vector3<float32_t>::BufferType& rhs) -> void {  // NOLINT
-    for (uint32_t i = 0; i < Vector3<float32_t>::VECTOR_NDIM; ++i) {
+auto kernel_add(Array3f& dst, const Array3f& lhs, const Array3f& rhs) -> void {
+    for (uint32_t i = 0; i < Vec3f::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] + rhs[i];
     }
 }
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_sub(Vector3<float32_t>::BufferType& dst,
-                const Vector3<float32_t>::BufferType& lhs,
-                const Vector3<float32_t>::BufferType& rhs) -> void {  // NOLINT
-    for (uint32_t i = 0; i < Vector3<float32_t>::VECTOR_NDIM; ++i) {
+auto kernel_sub(Array3f& dst, const Array3f& lhs, const Array3f& rhs) -> void {
+    for (uint32_t i = 0; i < Vec3f::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] - rhs[i];
+    }
+}
+
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_scale(Array3f& dst, float32_t scale, const Array3f& vec) -> void {
+    for (uint32_t i = 0; i < Vec3f::VECTOR_NDIM; ++i) {
+        dst[i] = scale * vec[i];
     }
 }
 
 // ***************************************************************************//
 //   Implementations for double-precision floating point numbers (float64_t)  //
 // ***************************************************************************//
+using Vec3d = Vector3<float64_t>;
+using Array3d = Vec3d::BufferType;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_add(Vector3<float64_t>::BufferType& dst,
-                const Vector3<float64_t>::BufferType& lhs,
-                const Vector3<float64_t>::BufferType& rhs) -> void {  // NOLINT
-    for (uint32_t i = 0; i < Vector3<float64_t>::VECTOR_NDIM; ++i) {
+auto kernel_add(Array3d& dst, const Array3d& lhs, const Array3d& rhs) -> void {
+    for (uint32_t i = 0; i < Vec3d::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] + rhs[i];
     }
 }
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_sub(Vector3<float64_t>::BufferType& dst,
-                const Vector3<float64_t>::BufferType& lhs,
-                const Vector3<float64_t>::BufferType& rhs) -> void {  // NOLINT
-    for (uint32_t i = 0; i < Vector3<float64_t>::VECTOR_NDIM; ++i) {
+auto kernel_sub(Array3d& dst, const Array3d& lhs, const Array3d& rhs) -> void {
+    for (uint32_t i = 0; i < Vec3d::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] - rhs[i];
+    }
+}
+
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_scale(Array3d& dst, float64_t scale, const Array3d& vec) -> void {
+    for (uint32_t i = 0; i < Vec3d::VECTOR_NDIM; ++i) {
+        dst[i] = scale * vec[i];
     }
 }
 

--- a/src/tinymath/impl/vec3_t_sse_impl.cpp
+++ b/src/tinymath/impl/vec3_t_sse_impl.cpp
@@ -11,11 +11,11 @@ namespace sse {
 // ***************************************************************************//
 //   Implementations for single-precision floating point numbers (float32_t)  //
 // ***************************************************************************//
+using Vec3f = Vector3<float32_t>;
+using Array3f = Vec3f::BufferType;
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_add(Vector3<float32_t>::BufferType& dst,
-                const Vector3<float32_t>::BufferType& lhs,
-                const Vector3<float32_t>::BufferType& rhs) -> void {  // NOLINT
+auto kernel_add(Array3f& dst, const Array3f& lhs, const Array3f& rhs) -> void {
     auto xmm_lhs = _mm_loadu_ps(lhs.data());
     auto xmm_rhs = _mm_loadu_ps(rhs.data());
     auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
@@ -23,12 +23,18 @@ auto kernel_add(Vector3<float32_t>::BufferType& dst,
 }
 
 // NOLINTNEXTLINE(runtime/references)
-auto kernel_sub(Vector3<float32_t>::BufferType& dst,
-                const Vector3<float32_t>::BufferType& lhs,
-                const Vector3<float32_t>::BufferType& rhs) -> void {  // NOLINT
+auto kernel_sub(Array3f& dst, const Array3f& lhs, const Array3f& rhs) -> void {
     auto xmm_lhs = _mm_loadu_ps(lhs.data());
     auto xmm_rhs = _mm_loadu_ps(rhs.data());
     auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
+    _mm_storeu_ps(dst.data(), xmm_result);
+}
+
+// NOLINTNEXTLINE(runtime/references)
+auto kernel_scale(Array3f& dst, float32_t scale, const Array3f& vec) -> void {
+    auto xmm_scale = _mm_set1_ps(scale);
+    auto xmm_vector = _mm_loadu_ps(vec.data());
+    auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
     _mm_storeu_ps(dst.data(), xmm_result);
 }
 

--- a/src/tinymath/vec3_t.cpp
+++ b/src/tinymath/vec3_t.cpp
@@ -48,9 +48,20 @@ template <>
 auto operator*(float32_t scale, const Vec3f& vec) -> Vec3f {
     Vec3f result;
 #if defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert): implement sse-float32 scale kernel
+    sse::kernel_scale(result.elements(), scale, vec.elements());
 #else
-    // @todo(wilbert): implement scalar scale kernel
+    scalar::kernel_scale(result.elements(), scale, vec.elements());
+#endif
+    return result;
+}
+
+template <>
+auto operator*(const Vec3f& vec, float32_t scale) -> Vec3f {
+    Vec3f result;
+#if defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_scale(result.elements(), scale, vec.elements());
+#else
+    scalar::kernel_scale(result.elements(), scale, vec.elements());
 #endif
     return result;
 }
@@ -88,9 +99,20 @@ template <>
 auto operator*(float64_t scale, const Vec3d& vec) -> Vec3d {
     Vec3d result;
 #if defined(TINYMATH_AVX_ENABLED)
-    // @todo(wilbert): implement sse-float64 scale kernel
+    avx::kernel_scale(result.elements(), scale, vec.elements());
 #else
-    // @todo(wilbert): implement scalar scale kernel
+    scalar::kernel_scale(result.elements(), scale, vec.elements());
+#endif
+    return result;
+}
+
+template <>
+auto operator*(const Vec3d& vec, float64_t scale) -> Vec3d {
+    Vec3d result;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_scale(result.elements(), scale, vec.elements());
+#else
+    scalar::kernel_scale(result.elements(), scale, vec.elements());
 #endif
     return result;
 }

--- a/src/tinymath/vec3_t.cpp
+++ b/src/tinymath/vec3_t.cpp
@@ -1,7 +1,5 @@
 #include <tinymath/impl/vec3_t_scalar_impl.hpp>
 
-#include "tinymath/common.hpp"
-
 #if defined(TINYMATH_SSE_ENABLED)
 #include <tinymath/impl/vec3_t_sse_impl.hpp>
 #endif
@@ -10,6 +8,7 @@
 #include <tinymath/impl/vec3_t_avx_impl.hpp>
 #endif
 
+#include <cmath>
 #include <tinymath/vec3_t.hpp>
 
 namespace tiny {
@@ -17,6 +16,26 @@ namespace math {
 
 // Specializations of operators for single-precision types (float32_t)
 using Vec3f = Vector3<float32_t>;
+
+template <>
+auto Vec3f::length_square() const -> float32_t {
+#if defined(TINYMATH_SSE_ENABLED)
+
+#else
+    return scalar::kernel_length_square(elements());
+#endif
+}
+
+template <>
+auto Vec3f::length() const -> float32_t {
+#if defined(TINYMATH_SSE_ENABLED)
+
+#elif defined(TINYMATH_AVX_ENABLED)
+
+#else
+    return std::sqrt(scalar::kernel_length_square(elements()));
+#endif
+}
 
 template <>
 auto operator+(const Vec3f& lhs, const Vec3f& rhs) -> Vec3f {
@@ -68,6 +87,26 @@ auto operator*(const Vec3f& vec, float32_t scale) -> Vec3f {
 
 // Specializations of operators for double-precision types (float64_t)
 using Vec3d = Vector3<float64_t>;
+
+template <>
+auto Vec3d::length_square() const -> float64_t {
+#if defined(TINYMATH_SSE_ENABLED)
+
+#else
+    return scalar::kernel_length_square(elements());
+#endif
+}
+
+template <>
+auto Vec3d::length() const -> float64_t {
+#if defined(TINYMATH_SSE_ENABLED)
+
+#elif defined(TINYMATH_AVX_ENABLED)
+
+#else
+    return std::sqrt(scalar::kernel_length_square(elements()));
+#endif
+}
 
 template <>
 auto operator+(const Vec3d& lhs, const Vec3d& rhs) -> Vec3d {

--- a/tests/cpp/test_vec3_operations.cpp
+++ b/tests/cpp/test_vec3_operations.cpp
@@ -68,4 +68,20 @@ TEMPLATE_TEST_CASE("Vector3 class (vec3_t) core Operations", "[vec3_t][ops]",
         REQUIRE(std::abs(v_2.y() - (val_y * scale)) < EPSILON);
         REQUIRE(std::abs(v_2.z() - (val_z * scale)) < EPSILON);
     }
+
+    SECTION("Vector length") {
+        auto val_x = GENERATE(as<T>{}, 1.0, 2.0, 3.0, 4.0);  // NOLINT
+        auto val_y = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);  // NOLINT
+        auto val_z = GENERATE(as<T>{}, 3.0, 5.0, 7.0, 9.0);  // NOLINT
+        Vector3 v(val_x, val_y, val_z);
+
+        auto length_square = val_x * val_x + val_y * val_y + val_z * val_z;
+        auto length = std::sqrt(length_square);
+
+        auto v_length_square = v.length_square();
+        auto v_length = v.length();
+
+        REQUIRE(std::abs(v_length_square - length_square) < EPSILON);
+        REQUIRE(std::abs(v_length - length) < EPSILON);
+    }
 }

--- a/tests/cpp/test_vec3_operations.cpp
+++ b/tests/cpp/test_vec3_operations.cpp
@@ -49,4 +49,23 @@ TEMPLATE_TEST_CASE("Vector3 class (vec3_t) core Operations", "[vec3_t][ops]",
         REQUIRE(std::abs(v_result.y() - (val_y_a - val_y_b)) < EPSILON);
         REQUIRE(std::abs(v_result.z() - (val_z_a - val_z_b)) < EPSILON);
     }
+
+    SECTION("Vector scale (by single scalar)") {
+        auto val_x = GENERATE(as<T>{}, 1.0, 2.0, 3.0, 4.0);     // NOLINT
+        auto val_y = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);     // NOLINT
+        auto val_z = GENERATE(as<T>{}, 3.0, 5.0, 7.0, 9.0);     // NOLINT
+        auto scale = GENERATE(as<T>{}, 0.25, 0.50, 0.75, 1.0);  // NOLINT
+
+        Vector3 v(val_x, val_y, val_z);
+        auto v_1 = scale * v;
+        auto v_2 = v * scale;
+
+        REQUIRE(std::abs(v_1.x() - (val_x * scale)) < EPSILON);
+        REQUIRE(std::abs(v_1.y() - (val_y * scale)) < EPSILON);
+        REQUIRE(std::abs(v_1.z() - (val_z * scale)) < EPSILON);
+
+        REQUIRE(std::abs(v_2.x() - (val_x * scale)) < EPSILON);
+        REQUIRE(std::abs(v_2.y() - (val_y * scale)) < EPSILON);
+        REQUIRE(std::abs(v_2.z() - (val_z * scale)) < EPSILON);
+    }
 }


### PR DESCRIPTION
## Description
Just to keep track of the ops to be implemented on `vec3_t`. Some have already been implemented with both `scalar` and `simd` kernels, but there are some that are still missing (at least to provide the same operations that the old implementation had)

### Requirements
- [ ] Addition
- [ ] Substraction
- [ ] Scalar product
- [ ] Length
- [ ] Dot product
- [ ] Cross product
- [ ] [Hadamard/Schur][1] product
- [ ] Normalization
- [ ] `==` and `!=` (allclose-like comparison)

[1]: <https://en.wikipedia.org/wiki/Hadamard_product_(matrices)> (hadamard-schur-product)