### PR TITLE
[fix]: issue with vectors' storage alignment (#5)

### DIFF
--- a/include/tinymath/vec3_t.hpp
+++ b/include/tinymath/vec3_t.hpp
@@ -76,7 +76,8 @@ class Vector3 {
     // @todo(wilbert): add union trick to handle xmm and ymm registers on SIMD
     // @todo(wilbert): use alignas(sizeof(T)*BUFFER_SIZE) to fix issue #5
 
-    BufferType m_Elements = {0, 0, 0, 0};
+    alignas(sizeof(Scalar_T) * BUFFER_SIZE) BufferType m_Elements = {0, 0, 0,
+                                                                     0};
 };
 
 template <typename Scalar_T>

--- a/include/tinymath/vec4_t.hpp
+++ b/include/tinymath/vec4_t.hpp
@@ -72,7 +72,8 @@ class Vector4 {
     // @todo(wilbert): add union trick to handle xmm and ymm registers on SIMD
     // @todo(wilbert): use alignas(sizeof(T)*BUFFER_SIZE) to fix issue #5
 
-    BufferType m_Elements = {0, 0, 0, 0};
+    alignas(sizeof(Scalar_T) * BUFFER_SIZE) BufferType m_Elements = {0, 0, 0,
+                                                                     0};
 };
 
 template <typename Scalar_T>

--- a/src/tinymath/impl/vec3_t_avx_impl.cpp
+++ b/src/tinymath/impl/vec3_t_avx_impl.cpp
@@ -30,42 +30,42 @@ using Array3d = Vec3d::BufferType;
 
 auto kernel_add_v3d(Array3d& dst, const Array3d& lhs, const Array3d& rhs)
     -> void {
-    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
-    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
+    auto ymm_lhs = _mm256_load_pd(lhs.data());
+    auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_add_pd(ymm_lhs, ymm_rhs);
-    _mm256_storeu_pd(dst.data(), ymm_result);
+    _mm256_store_pd(dst.data(), ymm_result);
 }
 
 auto kernel_sub_v3d(Array3d& dst, const Array3d& lhs, const Array3d& rhs)
     -> void {
-    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
-    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
+    auto ymm_lhs = _mm256_load_pd(lhs.data());
+    auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_sub_pd(ymm_lhs, ymm_rhs);
-    _mm256_storeu_pd(dst.data(), ymm_result);
+    _mm256_store_pd(dst.data(), ymm_result);
 }
 
 auto kernel_scale_v3d(Array3d& dst, float64_t scale, const Array3d& vec)
     -> void {
     auto ymm_scale = _mm256_set1_pd(scale);
-    auto ymm_vector = _mm256_loadu_pd(vec.data());
+    auto ymm_vector = _mm256_load_pd(vec.data());
     auto ymm_result = _mm256_mul_pd(ymm_scale, ymm_vector);
-    _mm256_storeu_pd(dst.data(), ymm_result);
+    _mm256_store_pd(dst.data(), ymm_result);
 }
 
 auto kernel_hadamard_v3d(Array3d& dst, const Array3d& lhs, const Array3d& rhs)
     -> void {
-    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
-    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
-    _mm256_storeu_pd(dst.data(), _mm256_mul_pd(ymm_lhs, ymm_rhs));
+    auto ymm_lhs = _mm256_load_pd(lhs.data());
+    auto ymm_rhs = _mm256_load_pd(rhs.data());
+    _mm256_store_pd(dst.data(), _mm256_mul_pd(ymm_lhs, ymm_rhs));
 }
 
 auto kernel_length_square_v3d(const Array3d& vec) -> float64_t {
     // Implementation based on this post: https://bit.ly/3lt3ts4
     // Instruction-sets required (AVX, SSE2)
     // -------------------------
-    // AVX:_mm256_loadu_pd,_mm256_mul_pd,_mm256_hadd_pd,_mm256_extractf128_pd
+    // AVX:_mm256_load_pd,_mm256_mul_pd,_mm256_hadd_pd,_mm256_extractf128_pd
     // SSE2: _mm_add_pd, _mm_sqrt_pd, _mm_cvtsd_f64
-    auto ymm_v = _mm256_loadu_pd(vec.data());
+    auto ymm_v = _mm256_load_pd(vec.data());
     auto ymm_prod = _mm256_mul_pd(ymm_v, ymm_v);
     auto ymm_hsum = _mm256_hadd_pd(ymm_prod, ymm_prod);
     auto xmm_lo_sum = _mm256_extractf128_pd(ymm_hsum, 0);
@@ -78,9 +78,9 @@ auto kernel_length_v3d(const Array3d& vec) -> float64_t {
     // Implementation based on this post: https://bit.ly/3lt3ts4
     // Instruction-sets required (AVX, SSE2)
     // -------------------------
-    // AVX: _mm256_loadu_pd,_mm256_mul_pd,_mm256_hadd_pd,_mm256_extractf128_pd
+    // AVX: _mm256_load_pd,_mm256_mul_pd,_mm256_hadd_pd,_mm256_extractf128_pd
     // SSE2: _mm_add_pd,_mm_sqrt_pd,_mm_cvtsd_f64
-    auto ymm_v = _mm256_loadu_pd(vec.data());
+    auto ymm_v = _mm256_load_pd(vec.data());
     auto ymm_prod = _mm256_mul_pd(ymm_v, ymm_v);
     auto ymm_hsum = _mm256_hadd_pd(ymm_prod, ymm_prod);
     auto xmm_lo_sum = _mm256_extractf128_pd(ymm_hsum, 0);
@@ -90,7 +90,7 @@ auto kernel_length_v3d(const Array3d& vec) -> float64_t {
 }
 
 auto kernel_normalize_in_place_v3d(Array3d& vec) -> void {
-    auto ymm_v = _mm256_loadu_pd(vec.data());
+    auto ymm_v = _mm256_load_pd(vec.data());
     auto ymm_prod = _mm256_mul_pd(ymm_v, ymm_v);
     // Construct the sum of squares into each double of a 256-bit register
     auto tmp_0 = _mm256_permute2f128_pd(ymm_prod, ymm_prod, 0x21);
@@ -100,12 +100,12 @@ auto kernel_normalize_in_place_v3d(Array3d& vec) -> void {
     auto tmp_3 = _mm256_sqrt_pd(tmp_2);
     // Normalize the vector and store the result back
     auto ymm_normalized = _mm256_div_pd(ymm_v, tmp_3);
-    _mm256_storeu_pd(vec.data(), ymm_normalized);
+    _mm256_store_pd(vec.data(), ymm_normalized);
 }
 
 auto kernel_dot_v3d(const Array3d& lhs, const Array3d& rhs) -> float64_t {
-    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
-    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
+    auto ymm_lhs = _mm256_load_pd(lhs.data());
+    auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_prod = _mm256_mul_pd(ymm_lhs, ymm_rhs);
     auto ymm_hsum = _mm256_hadd_pd(ymm_prod, ymm_prod);
     auto xmm_lo_sum = _mm256_extractf128_pd(ymm_hsum, 0);
@@ -117,8 +117,8 @@ auto kernel_dot_v3d(const Array3d& lhs, const Array3d& rhs) -> float64_t {
 auto kernel_cross_v3d(Array3d& dst, const Array3d& lhs, const Array3d& rhs)
     -> void {
     // Implementation adapted from @ian_mallett (https://bit.ly/3lu6pVe)
-    auto vec_a = _mm256_loadu_pd(lhs.data());
-    auto vec_b = _mm256_loadu_pd(rhs.data());
+    auto vec_a = _mm256_load_pd(lhs.data());
+    auto vec_b = _mm256_load_pd(rhs.data());
 
     // Construct both {a[1], a[2], a[0], 0} and {a[2], a[0], a[1], 0} **********
     auto tmp_0a = _mm256_permute2f128_pd(vec_a, vec_a, 0x21);
@@ -143,8 +143,8 @@ auto kernel_cross_v3d(Array3d& dst, const Array3d& lhs, const Array3d& rhs)
     auto tmp_5b = _mm256_blend_pd(tmp_1b, tmp_2b, 0x02);
     auto tmp_6b = _mm256_blend_pd(tmp_0b, tmp_5b, 0x0b);  // {b[1],b[2],b[0],0}
     // *************************************************************************
-    _mm256_storeu_pd(dst.data(), _mm256_sub_pd(_mm256_mul_pd(tmp_6a, tmp_4b),
-                                               _mm256_mul_pd(tmp_4a, tmp_6b)));
+    _mm256_store_pd(dst.data(), _mm256_sub_pd(_mm256_mul_pd(tmp_6a, tmp_4b),
+                                              _mm256_mul_pd(tmp_4a, tmp_6b)));
     // @todo(wilbert): replace permutation madness with "permute4x64_pd" (AVX2)
 }
 

--- a/src/tinymath/impl/vec3_t_sse_impl.cpp
+++ b/src/tinymath/impl/vec3_t_sse_impl.cpp
@@ -31,63 +31,63 @@ using Array3f = Vec3f::BufferType;
 
 auto kernel_add_v3f(Array3f& dst, const Array3f& lhs, const Array3f& rhs)
     -> void {
-    auto xmm_lhs = _mm_loadu_ps(lhs.data());
-    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_lhs = _mm_load_ps(lhs.data());
+    auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
-    _mm_storeu_ps(dst.data(), xmm_result);
+    _mm_store_ps(dst.data(), xmm_result);
 }
 
 auto kernel_sub_v3f(Array3f& dst, const Array3f& lhs, const Array3f& rhs)
     -> void {
-    auto xmm_lhs = _mm_loadu_ps(lhs.data());
-    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_lhs = _mm_load_ps(lhs.data());
+    auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
-    _mm_storeu_ps(dst.data(), xmm_result);
+    _mm_store_ps(dst.data(), xmm_result);
 }
 
 auto kernel_scale_v3f(Array3f& dst, float32_t scale, const Array3f& vec)
     -> void {
     auto xmm_scale = _mm_set1_ps(scale);
-    auto xmm_vector = _mm_loadu_ps(vec.data());
+    auto xmm_vector = _mm_load_ps(vec.data());
     auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
-    _mm_storeu_ps(dst.data(), xmm_result);
+    _mm_store_ps(dst.data(), xmm_result);
 }
 
 auto kernel_hadamard_v3f(Array3f& dst, const Array3f& lhs, const Array3f& rhs)
     -> void {
-    auto xmm_lhs = _mm_loadu_ps(lhs.data());
-    auto xmm_rhs = _mm_loadu_ps(rhs.data());
-    _mm_storeu_ps(dst.data(), _mm_mul_ps(xmm_lhs, xmm_rhs));
+    auto xmm_lhs = _mm_load_ps(lhs.data());
+    auto xmm_rhs = _mm_load_ps(rhs.data());
+    _mm_store_ps(dst.data(), _mm_mul_ps(xmm_lhs, xmm_rhs));
 }
 
 auto kernel_length_square_v3f(const Array3f& vec) -> float32_t {
     // Implementation based on this post: https://bit.ly/3FyZF0n
     constexpr int32_t COND_PROD_MASK = 0x71;
-    auto xmm_v = _mm_loadu_ps(vec.data());
+    auto xmm_v = _mm_load_ps(vec.data());
     return _mm_cvtss_f32(_mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK));
 }
 
 auto kernel_length_v3f(const Array3f& vec) -> float32_t {
     // Implementation based on this post: https://bit.ly/3FyZF0n
     constexpr int32_t COND_PROD_MASK = 0x71;
-    auto xmm_v = _mm_loadu_ps(vec.data());
+    auto xmm_v = _mm_load_ps(vec.data());
     return _mm_cvtss_f32(_mm_sqrt_ss(_mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK)));
 }
 
 auto kernel_normalize_in_place_v3f(Array3f& vec) -> void {
     // Implementation based on this post: https://bit.ly/3FyZF0n
     constexpr int32_t COND_PROD_MASK = 0x7f;
-    auto xmm_v = _mm_loadu_ps(vec.data());
+    auto xmm_v = _mm_load_ps(vec.data());
     auto xmm_sums = _mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK);
     auto xmm_r_sqrt_sums = _mm_sqrt_ps(xmm_sums);
     auto xmm_v_norm = _mm_div_ps(xmm_v, xmm_r_sqrt_sums);
-    _mm_storeu_ps(vec.data(), xmm_v_norm);
+    _mm_store_ps(vec.data(), xmm_v_norm);
 }
 
 auto kernel_dot_v3f(const Array3f& lhs, const Array3f& rhs) -> float32_t {
     constexpr int32_t COND_PROD_MASK = 0x71;
-    auto xmm_lhs = _mm_loadu_ps(lhs.data());
-    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_lhs = _mm_load_ps(lhs.data());
+    auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, COND_PROD_MASK);
     return _mm_cvtss_f32(xmm_cond_prod);
 };
@@ -104,8 +104,8 @@ auto kernel_cross_v3f(Array3f& dst, const Array3f& lhs, const Array3f& rhs)
     //            a[2] * b[0] - a[0] * b[2],
     //            a[0] * b[1] - a[1] * b[0],
     //                        0            ]
-    auto vec_0 = _mm_loadu_ps(lhs.data());  // a = {a[0], a[1], a[2], a[3]=0}
-    auto vec_1 = _mm_loadu_ps(rhs.data());  // b = {b[0], b[1], b[2], b[3]=0}
+    auto vec_0 = _mm_load_ps(lhs.data());  // a = {a[0], a[1], a[2], a[3]=0}
+    auto vec_1 = _mm_load_ps(rhs.data());  // b = {b[0], b[1], b[2], b[3]=0}
     // tmp_0 = {a[1], a[2], a[0], 0}
     auto tmp_0 = _mm_shuffle_ps(vec_0, vec_0, MASK_A);
     // tmp_1 = {b[2], b[0], b[1], 0}
@@ -114,8 +114,8 @@ auto kernel_cross_v3f(Array3f& dst, const Array3f& lhs, const Array3f& rhs)
     auto tmp_2 = _mm_shuffle_ps(vec_0, vec_0, MASK_B);
     // tmp_3 = {b[1], b[2], b[0], 0}
     auto tmp_3 = _mm_shuffle_ps(vec_1, vec_1, MASK_A);
-    _mm_storeu_ps(dst.data(), _mm_sub_ps(_mm_mul_ps(tmp_0, tmp_1),
-                                         _mm_mul_ps(tmp_2, tmp_3)));
+    _mm_store_ps(dst.data(), _mm_sub_ps(_mm_mul_ps(tmp_0, tmp_1),
+                                        _mm_mul_ps(tmp_2, tmp_3)));
 }
 
 }  // namespace sse

--- a/src/tinymath/impl/vec4_t_avx_impl.cpp
+++ b/src/tinymath/impl/vec4_t_avx_impl.cpp
@@ -26,39 +26,38 @@ using Array4d = Vec4d::BufferType;
 
 auto kernel_add_v4d(Array4d& dst, const Array4d& lhs, const Array4d& rhs)
     -> void {
-    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
-    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
+    auto ymm_lhs = _mm256_load_pd(lhs.data());
+    auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_add_pd(ymm_lhs, ymm_rhs);
-    // @todo(wilbert): check alignment (I thought it was already aligned :O)
-    _mm256_storeu_pd(dst.data(), ymm_result);
+    _mm256_store_pd(dst.data(), ymm_result);
 }
 
 auto kernel_sub_v4d(Array4d& dst, const Array4d& lhs, const Array4d& rhs)
     -> void {
-    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
-    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
+    auto ymm_lhs = _mm256_load_pd(lhs.data());
+    auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_sub_pd(ymm_lhs, ymm_rhs);
-    _mm256_storeu_pd(dst.data(), ymm_result);
+    _mm256_store_pd(dst.data(), ymm_result);
 }
 
 auto kernel_scale_v4d(Array4d& dst, float64_t scale, const Array4d& vec)
     -> void {
     auto ymm_scale = _mm256_set1_pd(scale);
-    auto ymm_vector = _mm256_loadu_pd(vec.data());
+    auto ymm_vector = _mm256_load_pd(vec.data());
     auto ymm_result = _mm256_mul_pd(ymm_scale, ymm_vector);
-    _mm256_storeu_pd(dst.data(), ymm_result);
+    _mm256_store_pd(dst.data(), ymm_result);
 }
 
 auto kernel_hadamard_v4d(Array4d& dst, const Array4d& lhs, const Array4d& rhs)
     -> void {
-    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
-    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
-    _mm256_storeu_pd(dst.data(), _mm256_mul_pd(ymm_lhs, ymm_rhs));
+    auto ymm_lhs = _mm256_load_pd(lhs.data());
+    auto ymm_rhs = _mm256_load_pd(rhs.data());
+    _mm256_store_pd(dst.data(), _mm256_mul_pd(ymm_lhs, ymm_rhs));
 }
 
 auto kernel_dot_v4d(const Array4d& lhs, const Array4d& rhs) -> float64_t {
-    auto ymm_lhs = _mm256_loadu_pd(lhs.data());
-    auto ymm_rhs = _mm256_loadu_pd(rhs.data());
+    auto ymm_lhs = _mm256_load_pd(lhs.data());
+    auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_prod = _mm256_mul_pd(ymm_lhs, ymm_rhs);
     auto ymm_hsum = _mm256_hadd_pd(ymm_prod, ymm_prod);
     auto xmm_lo_sum = _mm256_extractf128_pd(ymm_hsum, 0);

--- a/src/tinymath/impl/vec4_t_sse_impl.cpp
+++ b/src/tinymath/impl/vec4_t_sse_impl.cpp
@@ -28,42 +28,41 @@ using Array4f = Vec4f::BufferType;
 // NOLINTNEXTLINE(runtime/references)
 auto kernel_add_v4f(Array4f& dst, const Array4f& lhs, const Array4f& rhs)
     -> void {
-    auto xmm_lhs = _mm_loadu_ps(lhs.data());
-    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_lhs = _mm_load_ps(lhs.data());
+    auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
-    // @todo(wilbert): check alignment (I thought it was already aligned :O)
-    _mm_storeu_ps(dst.data(), xmm_result);
+    _mm_store_ps(dst.data(), xmm_result);
 }
 
 // NOLINTNEXTLINE(runtime/references)
 auto kernel_sub_v4f(Array4f& dst, const Array4f& lhs, const Array4f& rhs)
     -> void {
-    auto xmm_lhs = _mm_loadu_ps(lhs.data());
-    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_lhs = _mm_load_ps(lhs.data());
+    auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
-    _mm_storeu_ps(dst.data(), xmm_result);
+    _mm_store_ps(dst.data(), xmm_result);
 }
 
 // NOLINTNEXTLINE(runtime/references)
 auto kernel_scale_v4f(Array4f& dst, float32_t scale, const Array4f& vec)
     -> void {
     auto xmm_scale = _mm_set1_ps(scale);
-    auto xmm_vector = _mm_loadu_ps(vec.data());
+    auto xmm_vector = _mm_load_ps(vec.data());
     auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
-    _mm_storeu_ps(dst.data(), xmm_result);
+    _mm_store_ps(dst.data(), xmm_result);
 }
 
 auto kernel_hadamard_v4f(Array4f& dst, const Array4f& lhs, const Array4f& rhs)
     -> void {
-    auto xmm_lhs = _mm_loadu_ps(lhs.data());
-    auto xmm_rhs = _mm_loadu_ps(rhs.data());
-    _mm_storeu_ps(dst.data(), _mm_mul_ps(xmm_lhs, xmm_rhs));
+    auto xmm_lhs = _mm_load_ps(lhs.data());
+    auto xmm_rhs = _mm_load_ps(rhs.data());
+    _mm_store_ps(dst.data(), _mm_mul_ps(xmm_lhs, xmm_rhs));
 }
 
 auto kernel_dot_v4f(const Array4f& lhs, const Array4f& rhs) -> float32_t {
     constexpr int32_t COND_PROD_MASK = 0xf1;
-    auto xmm_lhs = _mm_loadu_ps(lhs.data());
-    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_lhs = _mm_load_ps(lhs.data());
+    auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, COND_PROD_MASK);
     return _mm_cvtss_f32(xmm_cond_prod);
 }


### PR DESCRIPTION
Changes:
* Adds the hint `alignas` to tell the compiler the proper alignment
  required by the vectors' storage buffers (`std::array`). This allowed
  us to change all `loadu_pX` and `storeu_pX` unaligned functions to the
  aligned versions in both SSE and AVX (`load_pX` and `store_pX`)

Closes #5