### PR TITLE
Matrix4 operations

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -17,7 +17,8 @@ set(TINYMATH_EXAMPLES_LIST
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec3_operations.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec4_constructors.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec4_operations.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/example_mat4_constructors.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/example_mat4_constructors.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/example_mat4_operations.cpp)
 
 # Create all the example targets
 foreach(example_filepath IN LISTS TINYMATH_EXAMPLES_LIST)

--- a/examples/cpp/example_mat4_operations.cpp
+++ b/examples/cpp/example_mat4_operations.cpp
@@ -1,0 +1,53 @@
+#include <tinymath/tinymath.hpp>
+#include <type_traits>
+
+template <typename T, typename = typename std::enable_if<
+                          tiny::math::IsScalar<T>::value>::type>
+auto run_operations_mat4() -> void {
+    using Mat4 = tiny::math::Matrix4<T>;
+
+    // Preamble (show the type we're currently working with)
+    if (std::is_same<T, float>()) {
+        std::cout << "Matrix4-float32 type:\n";
+    } else if (std::is_same<T, double>()) {
+        std::cout << "Matrix4-float64 type:\n";
+    }
+
+    // clang-format off
+    Mat4 mat_a(1.0,  2.0,  3.0,  4.0,
+               5.0,  6.0,  7.0,  8.0,
+               9.0,  10.0, 11.0, 12.0,
+               13.0, 14.0, 15.0, 16.0);
+
+    Mat4 mat_b(2.0,  4.0,  6.0,  8.0,
+               10.0, 12.0, 14.0, 16.0,
+               18.0, 20.0, 22.0, 24.0,
+               26.0, 28.0, 30.0, 32.0);
+    // clang-format on
+
+    Mat4 mat_sum = mat_a + mat_b;
+    Mat4 mat_diff = mat_a - mat_b;
+    Mat4 mat_scale_1 = 2.5 * mat_a;
+    Mat4 mat_scale_2 = mat_b * 0.25;
+    Mat4 mat_matmul = mat_a * mat_b;
+    Mat4 mat_hadamard = tiny::math::hadamard(mat_a, mat_b);
+
+    std::cout << "a: " << '\n' << mat_a.toString() << '\n';
+    std::cout << "b: " << '\n' << mat_b.toString() << '\n';
+    std::cout << "a + b: " << '\n' << mat_sum.toString() << '\n';
+    std::cout << "a - b: " << '\n' << mat_diff.toString() << '\n';
+    std::cout << "2.5 * a: " << '\n' << mat_scale_1.toString() << '\n';
+    std::cout << "b * 0.25: " << '\n' << mat_scale_2.toString() << '\n';
+    std::cout << "a * b: " << '\n' << mat_matmul.toString() << '\n';
+    std::cout << "a . b: " << '\n' << mat_hadamard.toString() << '\n';
+    std::cout << "a == b: " << '\n'
+              << ((mat_a == mat_b) ? "True" : "False") << '\n';
+    std::cout << "a != b: " << '\n'
+              << ((mat_a != mat_b) ? "True" : "False") << '\n';
+}
+
+auto main() -> int {
+    run_operations_mat4<float>();
+    run_operations_mat4<double>();
+    return 0;
+}

--- a/include/tinymath/common.hpp
+++ b/include/tinymath/common.hpp
@@ -66,6 +66,14 @@ template <typename Tp>
 struct CpuHasSIMD : public std::integral_constant<bool,
                 IsScalar<Tp>::value && (HAS_SSE::value || HAS_AVX::value)> {};
 
+template <typename Tp>
+struct CpuHasSSE : public std::integral_constant<bool,
+                IsScalar<Tp>::value && HAS_SSE::value> {};
+
+template <typename Tp>
+struct CpuHasAVX : public std::integral_constant<bool,
+                IsScalar<Tp>::value && HAS_AVX::value> {};
+
 // clang-format on
 
 }  // namespace math

--- a/include/tinymath/common.hpp
+++ b/include/tinymath/common.hpp
@@ -14,6 +14,8 @@
 #endif
 // clang-format on
 
+#include <type_traits>
+
 namespace tiny {
 namespace math {
 
@@ -32,6 +34,39 @@ struct ShuffleMask {
     // NOLINTNEXTLINE
     static constexpr uint value = (((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
 };
+
+#if defined(TINYMATH_SSE_ENABLED)
+using HAS_SSE = std::true_type;
+#else
+using HAS_SSE = std::false_type;
+#endif
+
+#if defined(TINYMATH_AVX_ENABLED)
+using HAS_AVX = std::true_type;
+#else
+using HAS_AVX = std::false_type;
+#endif
+
+// clang-format off
+template <typename Tp> struct IsFloat32 : public std::false_type {};
+template <> struct IsFloat32<float32_t> : public std::true_type {};
+
+template <typename Tp> struct IsFloat64 : public std::false_type {};
+template <> struct IsFloat64<float64_t> : public std::true_type {};
+
+template <typename Tp>
+struct IsScalar : public std::integral_constant<bool,
+                IsFloat32<Tp>::value || IsFloat64<Tp>::value> {};
+
+template <typename Tp>
+struct CpuNoSIMD : public std::integral_constant<bool,
+                IsScalar<Tp>::value && !HAS_SSE::value && !HAS_AVX::value> {};
+
+template <typename Tp>
+struct CpuHasSIMD : public std::integral_constant<bool,
+                IsScalar<Tp>::value && (HAS_SSE::value || HAS_AVX::value)> {};
+
+// clang-format on
 
 }  // namespace math
 }  // namespace tiny

--- a/include/tinymath/impl/mat4_t_avx_impl.hpp
+++ b/include/tinymath/impl/mat4_t_avx_impl.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#if defined(TINYMATH_AVX_ENABLED)
+
+#include <immintrin.h>
+
+#include <tinymath/mat4_t.hpp>
+#include <type_traits>
+
+namespace tiny {
+namespace math {
+namespace avx {
+
+template <typename T>
+using ArrayCols = typename Matrix4<T>::BufferType;
+
+// ***************************************************************************//
+//                    Dispatch AVX-kernel for matrix addition                 //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_add_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): AVX implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_add_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): AVX implementation for mat4-f64 matrices
+}
+
+// ***************************************************************************//
+//                 Dispatch AVX-kernel for matrix substraction                //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_sub_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): AVX implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_sub_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): AVX implementation for mat4-f64 matrices
+}
+
+// ***************************************************************************//
+//                Dispatch AVX-kernel for matrix-scalar product               //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_scale_mat4(ArrayCols<T>& dst, T scale,
+                                 const ArrayCols<T>& mat) -> void {
+    // @todo(wilbert): AVX implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_scale_mat4(ArrayCols<T>& dst, T scale,
+                                 const ArrayCols<T>& mat) -> void {
+    // @todo(wilbert): AVX implementation for mat4-f64 matrices
+}
+
+// ***************************************************************************//
+//                Dispatch AVX-kernel for matrix-matrix product               //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_matmul_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                  const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): AVX implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_matmul_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                  const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): AVX implementation for mat4-f64 matrices
+}
+
+// ***************************************************************************//
+//             Dispatch AVX-kernel for matrix element-wise product            //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_hadamard_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                    const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): AVX implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_hadamard_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                    const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): AVX implementation for mat64-f64 matrices
+}
+
+}  // namespace avx
+}  // namespace math
+}  // namespace tiny
+
+#endif  // TINYMATH_AVX_ENABLED

--- a/include/tinymath/impl/mat4_t_scalar_impl.hpp
+++ b/include/tinymath/impl/mat4_t_scalar_impl.hpp
@@ -8,32 +8,84 @@ namespace tiny {
 namespace math {
 namespace scalar {
 
-// ***************************************************************************//
-//   Implementations for single-precision floating point numbers (float32_t)  //
-// ***************************************************************************//
-using Mat4f = Matrix4<float32_t>;
-using ArrayCols4f = Mat4f::BufferType;
+template <typename T>
+using ArrayCols = typename Matrix4<T>::BufferType;
 
-TM_INLINE auto kernel_transpose_in_place_m4f(ArrayCols4f& cols) -> void {
-    for (int32_t i = 1; i < Mat4f::MATRIX_NDIM; ++i) {
-        for (int32_t j = 0; j < i; ++j) {
-            std::swap(cols[i][j], cols[j][i]);
+template <typename T>
+TM_INLINE auto kernel_transpose_inplace_mat4(ArrayCols<T>& cols) -> void {
+    for (int32_t col = 1; col < Matrix4<T>::MATRIX_NDIM; ++col) {
+        for (int32_t row = 0; row < Matrix4<T>::MATRIX_NDIM; ++row) {
+            std::swap(cols[col][row], cols[row][col]);
         }
     }
 }
 
-// ***************************************************************************//
-//   Implementations for double-precision floating point numbers (float64_t)  //
-// ***************************************************************************//
-using Mat4d = Matrix4<float64_t>;
-using ArrayCols4d = Mat4d::BufferType;
-
-TM_INLINE auto kernel_transpose_in_place_m4d(ArrayCols4d& cols) -> void {
-    for (int32_t i = 1; i < Mat4d::MATRIX_NDIM; ++i) {
-        for (int32_t j = 0; j < i; ++j) {
-            std::swap(cols[i][j], cols[j][i]);
+template <typename T>
+TM_INLINE auto kernel_add_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
+        for (int32_t idx = 0; idx < Matrix4<T>::MATRIX_NDIM; ++idx) {
+            dst[col][idx] = lhs[col][idx] + rhs[col][idx];
         }
     }
+}
+
+template <typename T>
+TM_INLINE auto kernel_sub_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
+        for (int32_t idx = 0; idx < Matrix4<T>::MATRIX_NDIM; ++idx) {
+            dst[col][idx] = lhs[col][idx] - rhs[col][idx];
+        }
+    }
+}
+
+template <typename T>
+TM_INLINE auto kernel_scale_mat4(ArrayCols<T>& dst, T scale,
+                                 const ArrayCols<T>& mat) -> void {
+    for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
+        for (int32_t idx = 0; idx < Matrix4<T>::MATRIX_NDIM; ++idx) {
+            dst[col][idx] = scale * mat[col][idx];
+        }
+    }
+}
+
+template <typename T>
+TM_INLINE auto kernel_matmul_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                  const ArrayCols<T>& rhs) -> void {
+    // We're assumming that dst is zero-initialized (default-constructor)
+    for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
+        for (int32_t row = 0; row < Matrix4<T>::MATRIX_NDIM; ++row) {
+            for (int32_t k = 0; k < Matrix4<T>::MATRIX_NDIM; ++k) {
+                dst[col][row] += lhs[k][row] * rhs[col][k];
+            }
+        }
+    }
+}
+
+template <typename T>
+TM_INLINE auto kernel_hadamard_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                    const ArrayCols<T>& rhs) -> void {
+    for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
+        for (int32_t idx = 0; idx < Matrix4<T>::MATRIX_NDIM; ++idx) {
+            dst[col][idx] = lhs[col][idx] * rhs[col][idx];
+        }
+    }
+}
+
+template <typename T>
+TM_INLINE auto kernel_compare_eq_mat4(const ArrayCols<T>& lhs,
+                                      const ArrayCols<T>& rhs) -> bool {
+    constexpr auto EPSILON = tiny::math::EPS<T>;
+    constexpr auto NDIM = Matrix4<T>::MATRIX_NDIM;
+    for (int32_t col = 0; col < NDIM; ++col) {
+        for (int32_t idx = 0; idx < NDIM; ++idx) {
+            if (std::abs(lhs[col][idx] - rhs[col][idx]) > EPSILON) {
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 }  // namespace scalar

--- a/include/tinymath/impl/mat4_t_sse_impl.hpp
+++ b/include/tinymath/impl/mat4_t_sse_impl.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#if defined(TINYMATH_SSE_ENABLED)
+
+#include <smmintrin.h>
+#include <xmmintrin.h>
+
+#include <tinymath/mat4_t.hpp>
+#include <type_traits>
+
+namespace tiny {
+namespace math {
+namespace sse {
+
+template <typename T>
+using ArrayCols = typename Matrix4<T>::BufferType;
+
+// ***************************************************************************//
+//                    Dispatch SSE-kernel for matrix addition                 //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_add_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): SSE implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_add_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): SSE implementation for mat4-f64 matrices
+}
+
+// ***************************************************************************//
+//                 Dispatch SSE-kernel for matrix substraction                //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_sub_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): SSE implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_sub_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                               const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): SSE implementation for mat4-f64 matrices
+}
+
+// ***************************************************************************//
+//                Dispatch SSE-kernel for matrix-scalar product               //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_scale_mat4(ArrayCols<T>& dst, T scale,
+                                 const ArrayCols<T>& mat) -> void {
+    // @todo(wilbert): SSE implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_scale_mat4(ArrayCols<T>& dst, T scale,
+                                 const ArrayCols<T>& mat) -> void {
+    // @todo(wilbert): SSE implementation for mat4-f64 matrices
+}
+
+// ***************************************************************************//
+//                Dispatch SSE-kernel for matrix-matrix product               //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_matmul_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                  const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): SSE implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_matmul_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                  const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): SSE implementation for mat4-f64 matrices
+}
+
+// ***************************************************************************//
+//             Dispatch SSE-kernel for matrix element-wise product            //
+// ***************************************************************************//
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_hadamard_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                    const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): SSE implementation for mat4-f32 matrices
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_hadamard_mat4(ArrayCols<T>& dst, const ArrayCols<T>& lhs,
+                                    const ArrayCols<T>& rhs) -> void {
+    // @todo(wilbert): SSE implementation for mat64-f64 matrices
+}
+
+}  // namespace sse
+}  // namespace math
+}  // namespace tiny
+
+#endif  // TINYMATH_SSE_ENABLED

--- a/include/tinymath/mat4_t.hpp
+++ b/include/tinymath/mat4_t.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
+// clang-format off
 #include <cassert>
 #include <istream>
 #include <ostream>
 #include <string>
+#include <utility>
+#include <type_traits>
+
 #include <tinymath/vec4_t.hpp>
+// clang-format on
 
 namespace tiny {
 namespace math {
@@ -218,35 +223,43 @@ class Mat4CommaInitializer {
     int32_t m_CurrentBuildIndex = MATRIX_FIRST_INDEX;
 };
 
-template <typename Scalar_T>
+template <typename Scalar_T,
+          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type>
 TM_INLINE auto operator+(const Matrix4<Scalar_T>& lhs,
                          const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T>;
 
-template <typename Scalar_T>
+template <typename Scalar_T,
+          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type>
 TM_INLINE auto operator-(const Matrix4<Scalar_T>& lhs,
                          const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T>;
 
-template <typename Scalar_T>
-TM_INLINE auto operator*(Scalar_T scale, const Matrix4<Scalar_T>& mat)
+template <typename Scalar_T,
+          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type>
+TM_INLINE auto operator*(double scale, const Matrix4<Scalar_T>& mat)
     -> Matrix4<Scalar_T>;
 
-template <typename Scalar_T>
-TM_INLINE auto operator*(const Matrix4<Scalar_T>& mat, Scalar_T scale)
+template <typename Scalar_T,
+          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type>
+TM_INLINE auto operator*(const Matrix4<Scalar_T>& mat, double scale)
     -> Matrix4<Scalar_T>;
 
-template <typename Scalar_T>
+template <typename Scalar_T,
+          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type>
 TM_INLINE auto operator*(const Matrix4<Scalar_T>& lhs,
                          const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T>;
 
-template <typename Scalar_T>
+template <typename Scalar_T,
+          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type>
 TM_INLINE auto hadamard(const Matrix4<Scalar_T>& lhs,
                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T>;
 
-template <typename Scalar_T>
+template <typename Scalar_T,
+          typename std::enable_if<IsScalar<Scalar_T>::value>::type>
 TM_INLINE auto operator==(const Matrix4<Scalar_T>& lhs,
                           const Matrix4<Scalar_T>& rhs) -> bool;
 
-template <typename Scalar_T>
+template <typename Scalar_T,
+          typename std::enable_if<IsScalar<Scalar_T>::value>::type>
 TM_INLINE auto operator!=(const Matrix4<Scalar_T>& lhs,
                           const Matrix4<Scalar_T>& rhs) -> bool;
 

--- a/include/tinymath/mat4_t.hpp
+++ b/include/tinymath/mat4_t.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cassert>
+#include <istream>
+#include <ostream>
 #include <string>
 #include <tinymath/vec4_t.hpp>
 
@@ -215,6 +217,46 @@ class Mat4CommaInitializer {
     /// Index of the current coefficient being built
     int32_t m_CurrentBuildIndex = MATRIX_FIRST_INDEX;
 };
+
+template <typename Scalar_T>
+TM_INLINE auto operator+(const Matrix4<Scalar_T>& lhs,
+                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T>;
+
+template <typename Scalar_T>
+TM_INLINE auto operator-(const Matrix4<Scalar_T>& lhs,
+                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T>;
+
+template <typename Scalar_T>
+TM_INLINE auto operator*(Scalar_T scale, const Matrix4<Scalar_T>& mat)
+    -> Matrix4<Scalar_T>;
+
+template <typename Scalar_T>
+TM_INLINE auto operator*(const Matrix4<Scalar_T>& mat, Scalar_T scale)
+    -> Matrix4<Scalar_T>;
+
+template <typename Scalar_T>
+TM_INLINE auto operator*(const Matrix4<Scalar_T>& lhs,
+                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T>;
+
+template <typename Scalar_T>
+TM_INLINE auto hadamard(const Matrix4<Scalar_T>& lhs,
+                        const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T>;
+
+template <typename Scalar_T>
+TM_INLINE auto operator==(const Matrix4<Scalar_T>& lhs,
+                          const Matrix4<Scalar_T>& rhs) -> bool;
+
+template <typename Scalar_T>
+TM_INLINE auto operator!=(const Matrix4<Scalar_T>& lhs,
+                          const Matrix4<Scalar_T>& rhs) -> bool;
+
+template <typename Scalar_T>
+auto operator<<(std::ostream& output_stream, const Matrix4<Scalar_T>& src)
+    -> std::ostream&;
+
+template <typename Scalar_T>
+auto operator>>(std::istream& input_stream, Matrix4<Scalar_T>& dst)
+    -> std::istream&;
 
 }  // namespace math
 }  // namespace tiny

--- a/include/tinymath/mat4_t_impl.hpp
+++ b/include/tinymath/mat4_t_impl.hpp
@@ -18,6 +18,9 @@
 #endif
 // clang-format on
 
+// @todo(wilbert): use std::enable_if and some traits to only specialize for
+// types when there is either SSE or AVX support enabled (to avoid repetition)
+
 namespace tiny {
 namespace math {
 
@@ -98,14 +101,111 @@ using Mat4f = Matrix4<float32_t>;
 
 template <>
 TM_INLINE auto Mat4f::transposeInPlace() -> void {
-    scalar::kernel_transpose_in_place_m4f(elements());
+    // scalar::kernel_transpose_inplace_mat4<float32_t>(elements());
+    scalar::kernel_transpose_inplace_mat4<float32_t>(elements());
 }
 
 template <>
 TM_INLINE auto Mat4f::transpose() const -> Mat4f {
     Mat4f result = *this;
-    scalar::kernel_transpose_in_place_m4f(result.elements());
+    scalar::kernel_transpose_inplace_mat4<float32_t>(result.elements());
     return result;
+}
+
+template <>
+TM_INLINE auto operator+(const Mat4f& lhs, const Mat4f& rhs) -> Mat4f {
+    Mat4f result;
+#if defined(TINYMATH_AVX_ENABLED)
+    // avx::kernel_sub_mat4f(result.elements(), lhs.elements(), rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    // sse::kernel_sub_mat4f(result.elements(), lhs.elements(), rhs.elements());
+#else
+    scalar::kernel_add_mat4<float32_t>(result.elements(), lhs.elements(),
+                                       rhs.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator-(const Mat4f& lhs, const Mat4f& rhs) -> Mat4f {
+    Mat4f result;
+#if defined(TINYMATH_AVX_ENABLED)
+    // avx::kernel_sub_mat4f(result.elements(), lhs.elements(), rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    // sse::kernel_sub_mat4f(result.elements(), lhs.elements(), rhs.elements());
+#else
+    scalar::kernel_sub_mat4<float32_t>(result.elements(), lhs.elements(),
+                                       rhs.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator*(float32_t scale, const Mat4f& mat) -> Mat4f {
+    Mat4f result;
+#if defined(TINYMATH_AVX_ENABLED)
+    // avx::kernel_scale_mat4f(result.elements(), scale, mat.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    // sse::kernel_scale_mat4f(result.elements(), scale, mat.elements());
+#else
+    scalar::kernel_scale_mat4<float32_t>(result.elements(), scale,
+                                         mat.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator*(const Mat4f& mat, float32_t scale) -> Mat4f {
+    Mat4f result;
+#if defined(TINYMATH_AVX_ENABLED)
+    // avx::kernel_scale_mat4f(result.elements(), scale, mat.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    // sse::kernel_scale_mat4f(result.elements(), scale, mat.elements());
+#else
+    scalar::kernel_scale_mat4<float32_t>(result.elements(), scale,
+                                         mat.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator*(const Mat4f& lhs, const Mat4f& rhs) -> Mat4f {
+    Mat4f result;
+#if defined(TINYMATH_AVX_ENABLED)
+// avx::kernel_matmul_mat4f(result.elements(), lhs.elements(), rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+// sse::kernel_matmul_mat4f(result.elements(), lhs.elements(), rhs.elements());
+#else
+    scalar::kernel_matmul_mat4<float32_t>(result.elements(), lhs.elements(),
+                                          rhs.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto hadamard(const Mat4f& lhs, const Mat4f& rhs) -> Mat4f {
+    Mat4f result;
+#if defined(TINYMATH_AVX_ENABLED)
+// avx::kernel_hadamard_mat4f(result.elements(),lhs.elements(),rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+// sse::kernel_hadamard_mat4f(result.elements(),lhs.elements(),rhs.elements());
+#else
+    scalar::kernel_matmul_mat4<float32_t>(result.elements(), lhs.elements(),
+                                          rhs.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator==(const Mat4f& lhs, const Mat4f& rhs) -> bool {
+    return scalar::kernel_compare_eq_mat4<float32_t>(lhs.elements(),
+                                                     rhs.elements());
+}
+
+template <>
+TM_INLINE auto operator!=(const Mat4f& lhs, const Mat4f& rhs) -> bool {
+    return !scalar::kernel_compare_eq_mat4<float32_t>(lhs.elements(),
+                                                      rhs.elements());
 }
 
 // ***************************************************************************//
@@ -115,14 +215,110 @@ using Mat4d = Matrix4<float64_t>;
 
 template <>
 TM_INLINE auto Mat4d::transposeInPlace() -> void {
-    scalar::kernel_transpose_in_place_m4d(elements());
+    scalar::kernel_transpose_inplace_mat4<float64_t>(elements());
 }
 
 template <>
 TM_INLINE auto Mat4d::transpose() const -> Mat4d {
     Mat4d result = *this;
-    scalar::kernel_transpose_in_place_m4d(result.elements());
+    scalar::kernel_transpose_inplace_mat4<float64_t>(result.elements());
     return result;
+}
+
+template <>
+TM_INLINE auto operator+(const Mat4d& lhs, const Mat4d& rhs) -> Mat4d {
+    Mat4d result;
+#if defined(TINYMATH_AVX_ENABLED)
+    // avx::kernel_sub_mat4d(result.elements(), lhs.elements(), rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    // sse::kernel_sub_mat4d(result.elements(), lhs.elements(), rhs.elements());
+#else
+    scalar::kernel_add_mat4<float64_t>(result.elements(), lhs.elements(),
+                                       rhs.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator-(const Mat4d& lhs, const Mat4d& rhs) -> Mat4d {
+    Mat4d result;
+#if defined(TINYMATH_AVX_ENABLED)
+    // avx::kernel_sub_mat4d(result.elements(), lhs.elements(), rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    // sse::kernel_sub_mat4d(result.elements(), lhs.elements(), rhs.elements());
+#else
+    scalar::kernel_sub_mat4<float64_t>(result.elements(), lhs.elements(),
+                                       rhs.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator*(float64_t scale, const Mat4d& mat) -> Mat4d {
+    Mat4d result;
+#if defined(TINYMATH_AVX_ENABLED)
+    // avx::kernel_scale_mat4d(result.elements(), scale, mat.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    // sse::kernel_scale_mat4d(result.elements(), scale, mat.elements());
+#else
+    scalar::kernel_scale_mat4<float64_t>(result.elements(), scale,
+                                         mat.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator*(const Mat4d& mat, float64_t scale) -> Mat4d {
+    Mat4d result;
+#if defined(TINYMATH_AVX_ENABLED)
+    // avx::kernel_scale_mat4d(result.elements(), scale, mat.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    // sse::kernel_scale_mat4d(result.elements(), scale, mat.elements());
+#else
+    scalar::kernel_scale_mat4<float64_t>(result.elements(), scale,
+                                         mat.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator*(const Mat4d& lhs, const Mat4d& rhs) -> Mat4d {
+    Mat4d result;
+#if defined(TINYMATH_AVX_ENABLED)
+// avx::kernel_matmul_mat4d(result.elements(), lhs.elements(), rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+// sse::kernel_matmul_mat4d(result.elements(), lhs.elements(), rhs.elements());
+#else
+    scalar::kernel_matmul_mat4<float64_t>(result.elements(), lhs.elements(),
+                                          rhs.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto hadamard(const Mat4d& lhs, const Mat4d& rhs) -> Mat4d {
+    Mat4d result;
+#if defined(TINYMATH_AVX_ENABLED)
+// avx::kernel_hadamard_mat4d(result.elements(),lhs.elements(),rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+// sse::kernel_hadamard_mat4d(result.elements(),lhs.elements(),rhs.elements());
+#else
+    scalar::kernel_matmul_mat4<float64_t>(result.elements(), lhs.elements(),
+                                          rhs.elements());
+#endif
+    return result;
+}
+
+template <>
+TM_INLINE auto operator==(const Mat4d& lhs, const Mat4d& rhs) -> bool {
+    return scalar::kernel_compare_eq_mat4<float64_t>(lhs.elements(),
+                                                     rhs.elements());
+}
+
+template <>
+TM_INLINE auto operator!=(const Mat4d& lhs, const Mat4d& rhs) -> bool {
+    return !scalar::kernel_compare_eq_mat4<float64_t>(lhs.elements(),
+                                                      rhs.elements());
 }
 
 }  // namespace math

--- a/include/tinymath/mat4_t_impl.hpp
+++ b/include/tinymath/mat4_t_impl.hpp
@@ -8,14 +8,10 @@
 #include <type_traits>
 
 #include <tinymath/impl/mat4_t_scalar_impl.hpp>
+#include <tinymath/impl/mat4_t_sse_impl.hpp>
+#include <tinymath/impl/mat4_t_avx_impl.hpp>
+#include "tinymath/common.hpp"
 
-#if defined(TINYMATH_SSE_ENABLED)
-// #include <tinymath/impl/mat4_t_sse_impl.hpp>
-#endif
-
-#if defined(TINYMATH_AVX_ENABLED)
-// #include <tinymath/impl/mat4_t_avx_impl.hpp>
-#endif
 // clang-format on
 
 // @todo(wilbert): refactor SFINAE usage to avoid extra duplication (should be
@@ -110,39 +106,19 @@ auto Matrix4<T>::Zeros() -> Matrix4<T> {
 // ***************************************************************************//
 
 template <typename Scalar_T,
-          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type* = nullptr>
+          typename std::enable_if<IsScalar<Scalar_T>::value>::type* = nullptr>
 TM_INLINE auto operator+(const Matrix4<Scalar_T>& lhs,
                          const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
     Matrix4<Scalar_T> result;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_add_mat4<Scalar_T>(result.elements(), lhs.elements(),
+                                   rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_add_mat4<Scalar_T>(result.elements(), lhs.elements(),
+                                   rhs.elements());
+#else
     scalar::kernel_add_mat4<Scalar_T>(result.elements(), lhs.elements(),
                                       rhs.elements());
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat32<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator+(const Matrix4<Scalar_T>& lhs,
-                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_add_mat4f(result.elements(), lhs.elements(), rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_add_mat4f(result.elements(), lhs.elements(), rhs.elements());
-#endif
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat64<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator+(const Matrix4<Scalar_T>& lhs,
-                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_add_mat4d(result.elements(), lhs.elements(), rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_add_mat4d(result.elements(), lhs.elements(), rhs.elements());
 #endif
     return result;
 }
@@ -152,39 +128,19 @@ TM_INLINE auto operator+(const Matrix4<Scalar_T>& lhs,
 // ***************************************************************************//
 
 template <typename Scalar_T,
-          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type* = nullptr>
+          typename std::enable_if<IsScalar<Scalar_T>::value>::type* = nullptr>
 TM_INLINE auto operator-(const Matrix4<Scalar_T>& lhs,
                          const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
     Matrix4<Scalar_T> result;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_sub_mat4<Scalar_T>(result.elements(), lhs.elements(),
+                                   rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernek_sub_mat4<Scalar_T>(result.elements(), lhs.elements(),
+                                   rhs.elements());
+#else
     scalar::kernel_sub_mat4<Scalar_T>(result.elements(), lhs.elements(),
                                       rhs.elements());
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat32<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator-(const Matrix4<Scalar_T>& lhs,
-                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_sub_mat4f(result.elements(), lhs.elements(), rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_sub_mat4f(result.elements(), lhs.elements(), rhs.elements());
-#endif
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat64<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator-(const Matrix4<Scalar_T>& lhs,
-                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_sub_mat4d(result.elements(), lhs.elements(), rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_sub_mat4d(result.elements(), lhs.elements(), rhs.elements());
 #endif
     return result;
 }
@@ -194,39 +150,17 @@ TM_INLINE auto operator-(const Matrix4<Scalar_T>& lhs,
 // ***************************************************************************//
 
 template <typename Scalar_T,
-          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type* = nullptr>
+          typename std::enable_if<IsScalar<Scalar_T>::value>::type* = nullptr>
 TM_INLINE auto operator*(double scale, const Matrix4<Scalar_T>& mat)
     -> Matrix4<Scalar_T> {
     Matrix4<Scalar_T> result;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_scale_mat4<Scalar_T>(result.elements(), scale, mat.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_scale_mat4<Scalar_T>(result.elements(), scale, mat.elements());
+#else
     scalar::kernel_scale_mat4<Scalar_T>(result.elements(), scale,
                                         mat.elements());
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat32<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator*(double scale, const Matrix4<Scalar_T>& mat)
-    -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_scale_mat4f(result.elements(), scale, mat.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_scale_mat4f(result.elements(), scale, mat.elements());
-#endif
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat64<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator*(double scale, const Matrix4<Scalar_T>& mat)
-    -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_scale_mat4d(result.elements(), scale, mat.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_scale_mat4d(result.elements(), scale, mat.elements());
 #endif
     return result;
 }
@@ -236,39 +170,17 @@ TM_INLINE auto operator*(double scale, const Matrix4<Scalar_T>& mat)
 // ***************************************************************************//
 
 template <typename Scalar_T,
-          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type* = nullptr>
+          typename std::enable_if<IsScalar<Scalar_T>::value>::type* = nullptr>
 TM_INLINE auto operator*(const Matrix4<Scalar_T>& mat, double scale)
     -> Matrix4<Scalar_T> {
     Matrix4<Scalar_T> result;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_scale_mat4<Scalar_T>(result.elements(), scale, mat.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_scale_mat4<Scalar_T>(result.elements(), scale, mat.elements());
+#else
     scalar::kernel_scale_mat4<Scalar_T>(result.elements(), scale,
                                         mat.elements());
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat32<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator*(const Matrix4<Scalar_T>& mat, double scale)
-    -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_scale_mat4f(result.elements(), scale, mat.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_scale_mat4f(result.elements(), scale, mat.elements());
-#endif
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat64<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator*(const Matrix4<Scalar_T>& mat, double scale)
-    -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_scale_mat4d(result.elements(), scale, mat.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_scale_mat4d(result.elements(), scale, mat.elements());
 #endif
     return result;
 }
@@ -278,39 +190,19 @@ TM_INLINE auto operator*(const Matrix4<Scalar_T>& mat, double scale)
 // ***************************************************************************//
 
 template <typename Scalar_T,
-          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type* = nullptr>
+          typename std::enable_if<IsScalar<Scalar_T>::value>::type* = nullptr>
 TM_INLINE auto operator*(const Matrix4<Scalar_T>& lhs,
                          const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
     Matrix4<Scalar_T> result;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_matmul_mat4<Scalar_T>(result.elements(), lhs.elements(),
+                                      rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_matmul_mat4<Scalar_T>(result.elements(), lhs.elements(),
+                                      rhs.elements());
+#else
     scalar::kernel_matmul_mat4<Scalar_T>(result.elements(), lhs.elements(),
                                          rhs.elements());
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat32<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator*(const Matrix4<Scalar_T>& lhs,
-                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_matmul_mat4f(result.elements(), lhs.elements(), rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_matmul_mat4f(result.elements(), lhs.elements(), rhs.elements());
-#endif
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat64<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto operator*(const Matrix4<Scalar_T>& lhs,
-                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_matmul_mat4d(result.elements(), lhs.elements(), rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_matmul_mat4d(result.elements(), lhs.elements(), rhs.elements());
 #endif
     return result;
 }
@@ -320,39 +212,19 @@ TM_INLINE auto operator*(const Matrix4<Scalar_T>& lhs,
 // ***************************************************************************//
 
 template <typename Scalar_T,
-          typename std::enable_if<CpuNoSIMD<Scalar_T>::value>::type* = nullptr>
+          typename std::enable_if<IsScalar<Scalar_T>::value>::type* = nullptr>
 TM_INLINE auto hadamard(const Matrix4<Scalar_T>& lhs,
                         const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
     Matrix4<Scalar_T> result;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_hadamard_mat4<Scalar_T>(result.elements(), lhs.elements(),
+                                        rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_hadamard_mat4<Scalar_T>(result.elements(), lhs.elements(),
+                                        rhs.elements());
+#else
     scalar::kernel_hadamard_mat4<Scalar_T>(result.elements(), lhs.elements(),
                                            rhs.elements());
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat32<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto hadamard(const Matrix4<Scalar_T>& lhs,
-                        const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_hadamard_mat4f(result.elements(),lhs.elements(),rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_hadamard_mat4f(result.elements(),lhs.elements(),rhs.elements());
-#endif
-    return result;
-}
-
-template <typename Scalar_T,
-          typename std::enable_if<CpuHasSIMD<Scalar_T>::value &&
-                                  IsFloat64<Scalar_T>::value>::type* = nullptr>
-TM_INLINE auto hadamard(const Matrix4<Scalar_T>& lhs,
-                        const Matrix4<Scalar_T>& rhs) -> Matrix4<Scalar_T> {
-    Matrix4<Scalar_T> result;
-#if defined(TINYMATH_AVX_ENABLED)
-// avx::kernel_hadamard_mat4d(result.elements(),lhs.elements(),rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
-// sse::kernel_hadamard_mat4d(result.elements(),lsh.elements(),rhs.elements());
 #endif
     return result;
 }

--- a/include/tinymath/mat4_t_impl.hpp
+++ b/include/tinymath/mat4_t_impl.hpp
@@ -27,6 +27,11 @@
 // supposed to use enable_if on the return type side, as Eigen does in its
 // codebase (which gets a little verbose, but still works)
 
+// SFINAE implementation based on these resources:
+// * https://youtu.be/Vkck4EU2lOU
+// * https://akrzemi1.wordpress.com/examples/overloading-enable_if/
+// * https://youtu.be/ybaE9qlhHvw
+
 namespace tiny {
 namespace math {
 


### PR DESCRIPTION
## Description
Just to keep track of the ops to be implemented on `mat4_t`. Some have already been implemented with `scalar` kernels, but there's still missing support for `SIMD` (both `SSE` and `AVX`)

### Requirements
|        Kernel        |          Implementation         |
|----------------------|---------------------------------|
| Addition             |<ul><li>[x] Scalar </li><li>[ ] SSE </li><li>[ ] AVX </li></ul>|
| Substraction         |<ul><li>[x] Scalar </li><li>[ ] SSE </li><li>[ ] AVX </li></ul>|
| Scalar product       |<ul><li>[x] Scalar </li><li>[ ] SSE </li><li>[ ] AVX </li></ul>|
| Mattrix product      |<ul><li>[x] Scalar </li><li>[ ] SSE </li><li>[ ] AVX </li></ul>|
| Element-wise product |<ul><li>[x] Scalar </li><li>[ ] SSE </li><li>[ ] AVX </li></ul>|
| `==` and `!=`        |<ul><li>[x] Scalar </li><li>[ ] SSE </li><li>[ ] AVX </li></ul>|
| Input stream (`>>`)  |<ul><li>[ ] Scalar </li><li>[ ] SSE </li><li>[ ] AVX </li></ul>|
| Output stream (`<<`) |<ul><li>[ ] Scalar </li><li>[ ] SSE </li><li>[ ] AVX </li></ul>|
