### PR TITLE
Refactor vec3 types using SFINAE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Folder-exclusions
 build/
 dist/
+temp/
 Testing/
 .cache/
 

--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -169,8 +169,11 @@ function(tmSetupCompileProperties)
   if(TM_SETUP_USE_SIMD)
     target_compile_definitions(${TM_SETUP_TARGET}
                                INTERFACE -D${TM_SETUP_PROJECT_NAME}_SSE_ENABLED)
-    target_compile_definitions(${TM_SETUP_TARGET}
-                               INTERFACE -D${TM_SETUP_PROJECT_NAME}_AVX_ENABLED)
+    # ~~~
+    # testing only SSE
+    # target_compile_definitions(${TM_SETUP_TARGET}
+    #                            INTERFACE -D${TM_SETUP_PROJECT_NAME}_AVX_ENABL)
+    # ~~~
     # Enable compile-options according to each compiler variant
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
       target_compile_options(${TM_SETUP_TARGET} INTERFACE -msse -msse2 -msse4.1

--- a/examples/cpp/example_vec3_operations.cpp
+++ b/examples/cpp/example_vec3_operations.cpp
@@ -21,11 +21,14 @@ auto main() -> int {
         printVector(vec_c);
         printVector(vec_d);
 
-        std::cout << "dot-vec3f(a,b): " << vec_a.dot(vec_b) << "\n";
-        std::cout << "len^2-vec3f(a): " << vec_a.squaredNorm() << "\n";
-        std::cout << "len^2-vec3f(b): " << vec_b.squaredNorm() << "\n";
-        std::cout << "len-vec3f(a): " << vec_a.norm() << "\n";
-        std::cout << "len-vec3f(b): " << vec_b.norm() << "\n";
+        std::cout << "dot-vec3f(a,b): " << tiny::math::dot(vec_a, vec_b)
+                  << "\n";
+        std::cout << "len^2-vec3f(a): " << tiny::math::squareNorm(vec_a)
+                  << "\n";
+        std::cout << "len^2-vec3f(b): " << tiny::math::squareNorm(vec_b)
+                  << "\n";
+        std::cout << "len-vec3f(a): " << tiny::math::norm(vec_a) << "\n";
+        std::cout << "len-vec3f(b): " << tiny::math::norm(vec_b) << "\n";
     }
 
     {
@@ -38,11 +41,14 @@ auto main() -> int {
         printVector(vec_c);
         printVector(vec_d);
 
-        std::cout << "dot-vec3d(a,b): " << vec_a.dot(vec_b) << "\n";
-        std::cout << "len^2-vec3d(a): " << vec_a.squaredNorm() << "\n";
-        std::cout << "len^2-vec3d(b): " << vec_b.squaredNorm() << "\n";
-        std::cout << "len-vec3d(a): " << vec_a.norm() << "\n";
-        std::cout << "len-vec3d(b): " << vec_b.norm() << "\n";
+        std::cout << "dot-vec3d(a,b): " << tiny::math::dot(vec_a, vec_b)
+                  << "\n";
+        std::cout << "len^2-vec3d(a): " << tiny::math::squareNorm(vec_a)
+                  << "\n";
+        std::cout << "len^2-vec3d(b): " << tiny::math::squareNorm(vec_b)
+                  << "\n";
+        std::cout << "len-vec3d(a): " << tiny::math::norm(vec_a) << "\n";
+        std::cout << "len-vec3d(b): " << tiny::math::norm(vec_b) << "\n";
     }
 
     return 0;

--- a/include/tinymath/impl/vec3_t_avx_impl.hpp
+++ b/include/tinymath/impl/vec3_t_avx_impl.hpp
@@ -24,44 +24,128 @@ namespace tiny {
 namespace math {
 namespace avx {
 
-// ***************************************************************************//
-//   Implementations for double-precision floating point numbers (float64_t)  //
-// ***************************************************************************//
-using Vec3d = Vector3<float64_t>;
-using Array3d = Vec3d::BufferType;
+template <typename T>
+using ArrayBuffer = typename Vector3<T>::BufferType;
 
-TM_INLINE auto kernel_add_v3d(Array3d& dst, const Array3d& lhs,
-                              const Array3d& rhs) -> void {
+template <typename T>
+constexpr int32_t VECTOR_NDIM = Vector3<T>::VECTOR_NDIM;
+
+template <typename T>
+constexpr int32_t BUFFER_SIZE = Vector3<T>::BUFFER_SIZE;
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_add_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+    auto ymm_lhs = _mm256_load_ps(lhs.data());
+    auto ymm_rhs = _mm256_load_ps(rhs.data());
+    auto ymm_result = _mm256_add_ps(ymm_lhs, ymm_rhs);
+    _mm256_zeroupper();
+    _mm256_store_ps(dst.data(), ymm_result);
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_add_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_add_pd(ymm_lhs, ymm_rhs);
     _mm256_store_pd(dst.data(), ymm_result);
 }
 
-TM_INLINE auto kernel_sub_v3d(Array3d& dst, const Array3d& lhs,
-                              const Array3d& rhs) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_sub_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+    auto ymm_lhs = _mm256_load_ps(lhs.data());
+    auto ymm_rhs = _mm256_load_ps(rhs.data());
+    auto ymm_result = _mm256_sub_ps(ymm_lhs, ymm_rhs);
+    _mm256_zeroupper();
+    _mm256_store_ps(dst.data(), ymm_result);
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_sub_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_sub_pd(ymm_lhs, ymm_rhs);
     _mm256_store_pd(dst.data(), ymm_result);
 }
 
-TM_INLINE auto kernel_scale_v3d(Array3d& dst, float64_t scale,
-                                const Array3d& vec) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_scale_vec3(ArrayBuffer<T>& dst, T scale,
+                                 const ArrayBuffer<T>& vec) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+    auto ymm_scale = _mm256_set1_ps(scale);
+    auto ymm_vector = _mm256_load_ps(vec.data());
+    auto ymm_result = _mm256_mul_ps(ymm_scale, ymm_vector);
+    _mm256_zeroupper();
+    _mm256_store_ps(dst.data(), ymm_result);
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_scale_vec3(ArrayBuffer<T>& dst, T scale,
+                                 const ArrayBuffer<T>& vec) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
     auto ymm_scale = _mm256_set1_pd(scale);
     auto ymm_vector = _mm256_load_pd(vec.data());
     auto ymm_result = _mm256_mul_pd(ymm_scale, ymm_vector);
     _mm256_store_pd(dst.data(), ymm_result);
 }
 
-TM_INLINE auto kernel_hadamard_v3d(Array3d& dst, const Array3d& lhs,
-                                   const Array3d& rhs) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_hadamard_vec3(ArrayBuffer<T>& dst,
+                                    const ArrayBuffer<T>& lhs,
+                                    const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+    auto ymm_lhs = _mm256_load_ps(lhs.data());
+    auto ymm_rhs = _mm256_load_ps(rhs.data());
+    auto ymm_result = _mm256_mul_ps(ymm_lhs, ymm_rhs);
+    _mm256_zeroupper();
+    _mm256_store_ps(dst.data(), ymm_result);
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_hadamard_vec3(ArrayBuffer<T>& dst,
+                                    const ArrayBuffer<T>& lhs,
+                                    const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     _mm256_store_pd(dst.data(), _mm256_mul_pd(ymm_lhs, ymm_rhs));
 }
 
-TM_INLINE auto kernel_length_square_v3d(const Array3d& vec) -> float64_t {
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_length_square_vec3(const ArrayBuffer<T>& vec) -> T {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_length_square_vec3(const ArrayBuffer<T>& vec) -> T {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
     // Implementation based on this post: https://bit.ly/3lt3ts4
     // Instruction-sets required (AVX, SSE2)
     // -------------------------
@@ -76,7 +160,18 @@ TM_INLINE auto kernel_length_square_v3d(const Array3d& vec) -> float64_t {
     return _mm_cvtsd_f64(xmm_result);
 }
 
-TM_INLINE auto kernel_length_v3d(const Array3d& vec) -> float64_t {
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_length_vec3(const ArrayBuffer<T>& vec) -> T {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_length_vec3(const ArrayBuffer<T>& vec) -> T {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
     // Implementation based on this post: https://bit.ly/3lt3ts4
     // Instruction-sets required (AVX, SSE2)
     // -------------------------
@@ -91,7 +186,18 @@ TM_INLINE auto kernel_length_v3d(const Array3d& vec) -> float64_t {
     return _mm_cvtsd_f64(xmm_result);
 }
 
-TM_INLINE auto kernel_normalize_in_place_v3d(Array3d& vec) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_normalize_in_place_vec3(ArrayBuffer<T>& vec) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_normalize_in_place_vec3(ArrayBuffer<T>& vec) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
     auto ymm_v = _mm256_load_pd(vec.data());
     auto ymm_prod = _mm256_mul_pd(ymm_v, ymm_v);
     // Construct the sum of squares into each double of a 256-bit register
@@ -105,8 +211,20 @@ TM_INLINE auto kernel_normalize_in_place_v3d(Array3d& vec) -> void {
     _mm256_store_pd(vec.data(), ymm_normalized);
 }
 
-TM_INLINE auto kernel_dot_v3d(const Array3d& lhs, const Array3d& rhs)
-    -> float64_t {
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_dot_vec3(const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> T {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_dot_vec3(const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> T {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_prod = _mm256_mul_pd(ymm_lhs, ymm_rhs);
@@ -117,8 +235,20 @@ TM_INLINE auto kernel_dot_v3d(const Array3d& lhs, const Array3d& rhs)
     return _mm_cvtsd_f64(xmm_result);
 }
 
-TM_INLINE auto kernel_cross_v3d(Array3d& dst, const Array3d& lhs,
-                                const Array3d& rhs) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_cross_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                                 const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasAVX<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_cross_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                                 const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
     // Implementation adapted from @ian_mallett (https://bit.ly/3lu6pVe)
     auto vec_a = _mm256_load_pd(lhs.data());
     auto vec_b = _mm256_load_pd(rhs.data());

--- a/include/tinymath/impl/vec3_t_scalar_impl.hpp
+++ b/include/tinymath/impl/vec3_t_scalar_impl.hpp
@@ -7,142 +7,92 @@ namespace tiny {
 namespace math {
 namespace scalar {
 
-// ***************************************************************************//
-//   Implementations for single-precision floating point numbers (float32_t)  //
-// ***************************************************************************//
-using Vec3f = Vector3<float32_t>;
-using Array3f = Vec3f::BufferType;
+template <typename T>
+using ArrayBuffer = typename Vector3<T>::BufferType;
 
-TM_INLINE auto kernel_add_v3f(Array3f& dst, const Array3f& lhs,
-                              const Array3f& rhs) -> void {
-    for (int32_t i = 0; i < Vec3f::VECTOR_NDIM; ++i) {
+template <typename T>
+constexpr int32_t NUM_ELEMENTS = Vector3<T>::VECTOR_NDIM;
+
+template <typename T>
+TM_INLINE auto kernel_add_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> void {
+    for (int32_t i = 0; i < NUM_ELEMENTS<T>; ++i) {
         dst[i] = lhs[i] + rhs[i];
     }
 }
 
-TM_INLINE auto kernel_sub_v3f(Array3f& dst, const Array3f& lhs,
-                              const Array3f& rhs) -> void {
-    for (int32_t i = 0; i < Vec3f::VECTOR_NDIM; ++i) {
+template <typename T>
+TM_INLINE auto kernel_sub_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> void {
+    for (int32_t i = 0; i < NUM_ELEMENTS<T>; ++i) {
         dst[i] = lhs[i] - rhs[i];
     }
 }
 
-TM_INLINE auto kernel_scale_v3f(Array3f& dst, float32_t scale,
-                                const Array3f& vec) -> void {
-    for (int32_t i = 0; i < Vec3f::VECTOR_NDIM; ++i) {
+template <typename T>
+TM_INLINE auto kernel_scale_vec3(ArrayBuffer<T>& dst, T scale,
+                                 const ArrayBuffer<T>& vec) -> void {
+    for (int32_t i = 0; i < NUM_ELEMENTS<T>; ++i) {
         dst[i] = scale * vec[i];
     }
 }
 
-TM_INLINE auto kernel_hadamard_v3f(Array3f& dst, const Array3f& lhs,
-                                   const Array3f& rhs) -> void {
-    for (int32_t i = 0; i < Vec3f::VECTOR_NDIM; ++i) {
+template <typename T>
+TM_INLINE auto kernel_hadamard_vec3(ArrayBuffer<T>& dst,
+                                    const ArrayBuffer<T>& lhs,
+                                    const ArrayBuffer<T>& rhs) -> void {
+    for (int32_t i = 0; i < NUM_ELEMENTS<T>; ++i) {
         dst[i] = lhs[i] * rhs[i];
     }
 }
 
-TM_INLINE auto kernel_length_square_v3f(const Array3f& vec) -> float32_t {
-    return vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2];
+template <typename T>
+TM_INLINE auto kernel_length_square_vec3(const ArrayBuffer<T>& vec) -> T {
+    T accum = static_cast<T>(0.0);
+    for (int32_t i = 0; i < NUM_ELEMENTS<T>; ++i) {
+        accum += vec[i] * vec[i];
+    }
+    return accum;
 }
 
-TM_INLINE auto kernel_normalize_in_place_v3f(Array3f& vec) -> void {
-    auto norm = std::sqrt(kernel_length_square_v3f(vec));
-    vec[0] = vec[0] / norm;
-    vec[1] = vec[1] / norm;
-    vec[2] = vec[2] / norm;
+template <typename T>
+TM_INLINE auto kernel_normalize_in_place_vec3(ArrayBuffer<T>& vec) -> void {
+    auto length = std::sqrt(kernel_length_square_vec3<T>(vec));
+    for (int32_t i = 0; i < NUM_ELEMENTS<T>; ++i) {
+        vec[i] /= length;
+    }
 }
 
-TM_INLINE auto kernel_dot_v3f(const Array3f& lhs, const Array3f& rhs)
-    -> float32_t {
-    return lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2];
+template <typename T>
+TM_INLINE auto kernel_dot_vec3(const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> T {
+    T accum = static_cast<T>(0.0);
+    for (int32_t i = 0; i < NUM_ELEMENTS<T>; ++i) {
+        accum += lhs[i] * rhs[i];
+    }
+    return accum;
 }
 
-TM_INLINE auto kernel_cross_v3f(Array3f& dst, const Array3f& lhs,
-                                const Array3f& rhs) -> void {
+template <typename T>
+TM_INLINE auto kernel_compare_eq_vec3(const ArrayBuffer<T>& lhs,
+                                      const ArrayBuffer<T>& rhs) -> bool {
+    for (int32_t i = 0; i < NUM_ELEMENTS<T>; ++i) {
+        if (std::abs(lhs[i] - rhs[i]) >= tiny::math::EPS<T>) {
+            return false;
+        }
+    }
+    return true;
+}
+
+template <typename T>
+TM_INLINE auto kernel_cross_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                                 const ArrayBuffer<T>& rhs) -> void {
     // v.x =  v1.y  *  v2.z  -  v1.z  *  v2.y
     dst[0] = lhs[1] * rhs[2] - lhs[2] * rhs[1];
     // v.y =  v1.z  *  v2.x  -  v1.x  *  v2.z
     dst[1] = lhs[2] * rhs[0] - lhs[0] * rhs[2];
     // v.z =  v1.x  *  v2.y  -  v1.y  *  v2.x
     dst[2] = lhs[0] * rhs[1] - lhs[1] * rhs[0];
-}
-
-TM_INLINE auto kernel_compare_eq_v3f(const Array3f& lhs, const Array3f& rhs)
-    -> bool {
-    // Check all-close within an epsilon (EPS)
-    constexpr auto EPSILON = tiny::math::EPS<float32_t>;
-    return (std::abs(lhs[0] - rhs[0]) < EPSILON) &&
-           (std::abs(lhs[1] - rhs[1]) < EPSILON) &&
-           (std::abs(lhs[2] - rhs[2]) < EPSILON);
-}
-
-// ***************************************************************************//
-//   Implementations for double-precision floating point numbers (float64_t)  //
-// ***************************************************************************//
-using Vec3d = Vector3<float64_t>;
-using Array3d = Vec3d::BufferType;
-
-TM_INLINE auto kernel_add_v3d(Array3d& dst, const Array3d& lhs,
-                              const Array3d& rhs) -> void {
-    for (int32_t i = 0; i < Vec3d::VECTOR_NDIM; ++i) {
-        dst[i] = lhs[i] + rhs[i];
-    }
-}
-
-TM_INLINE auto kernel_sub_v3d(Array3d& dst, const Array3d& lhs,
-                              const Array3d& rhs) -> void {
-    for (int32_t i = 0; i < Vec3d::VECTOR_NDIM; ++i) {
-        dst[i] = lhs[i] - rhs[i];
-    }
-}
-
-TM_INLINE auto kernel_scale_v3d(Array3d& dst, float64_t scale,
-                                const Array3d& vec) -> void {
-    for (int32_t i = 0; i < Vec3d::VECTOR_NDIM; ++i) {
-        dst[i] = scale * vec[i];
-    }
-}
-
-TM_INLINE auto kernel_hadamard_v3d(Array3d& dst, const Array3d& lhs,
-                                   const Array3d& rhs) -> void {
-    for (int32_t i = 0; i < Vec3d::VECTOR_NDIM; ++i) {
-        dst[i] = lhs[i] * rhs[i];
-    }
-}
-
-TM_INLINE auto kernel_length_square_v3d(const Array3d& vec) -> float64_t {
-    return vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2];
-}
-
-TM_INLINE auto kernel_normalize_in_place_v3d(Array3d& vec) -> void {
-    auto norm = std::sqrt(kernel_length_square_v3d(vec));
-    vec[0] = vec[0] / norm;
-    vec[1] = vec[1] / norm;
-    vec[2] = vec[2] / norm;
-}
-
-TM_INLINE auto kernel_dot_v3d(const Array3d& lhs, const Array3d& rhs)
-    -> float64_t {
-    return lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2];
-}
-
-TM_INLINE auto kernel_cross_v3d(Array3d& dst, const Array3d& lhs,
-                                const Array3d& rhs) -> void {
-    // v.x =  v1.y  *  v2.z  -  v1.z  *  v2.y
-    dst[0] = lhs[1] * rhs[2] - lhs[2] * rhs[1];
-    // v.y =  v1.z  *  v2.x  -  v1.x  *  v2.z
-    dst[1] = lhs[2] * rhs[0] - lhs[0] * rhs[2];
-    // v.z =  v1.x  *  v2.y  -  v1.y  *  v2.x
-    dst[2] = lhs[0] * rhs[1] - lhs[1] * rhs[0];
-}
-
-TM_INLINE auto kernel_compare_eq_v3d(const Array3d& lhs, const Array3d& rhs)
-    -> bool {
-    // Check all-close within an epsilon (EPS)
-    constexpr auto EPSILON = tiny::math::EPS<float64_t>;
-    return (std::abs(lhs[0] - rhs[0]) < EPSILON) &&
-           (std::abs(lhs[1] - rhs[1]) < EPSILON) &&
-           (std::abs(lhs[2] - rhs[2]) < EPSILON);
 }
 
 }  // namespace scalar

--- a/include/tinymath/impl/vec3_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec3_t_sse_impl.hpp
@@ -70,42 +70,109 @@ TM_INLINE auto kernel_add_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
     _mm_store_pd(dst.data() + 2, xmm_result_hi);
 }
 
-// ***************************************************************************//
-//   Implementations for single-precision floating point numbers (float32_t)  //
-// ***************************************************************************//
-using Vec3f = Vector3<float32_t>;
-using Array3f = Vec3f::BufferType;
-
-TM_INLINE auto kernel_add_v3f(Array3f& dst, const Array3f& lhs,
-                              const Array3f& rhs) -> void {
-    auto xmm_lhs = _mm_load_ps(lhs.data());
-    auto xmm_rhs = _mm_load_ps(rhs.data());
-    auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
-    _mm_store_ps(dst.data(), xmm_result);
-}
-
-TM_INLINE auto kernel_sub_v3f(Array3f& dst, const Array3f& lhs,
-                              const Array3f& rhs) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_sub_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
     _mm_store_ps(dst.data(), xmm_result);
 }
 
-TM_INLINE auto kernel_scale_v3f(Array3f& dst, float32_t scale,
-                                const Array3f& vec) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_sub_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
+    auto xmm_lhs_lo = _mm_load_pd(lhs.data());
+    auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);
+    auto xmm_rhs_lo = _mm_load_pd(rhs.data());
+    auto xmm_rhs_hi = _mm_load_pd(rhs.data() + 2);
+    auto xmm_result_lo = _mm_sub_pd(xmm_lhs_lo, xmm_rhs_lo);
+    auto xmm_result_hi = _mm_sub_pd(xmm_lhs_hi, xmm_rhs_hi);
+    _mm_store_pd(dst.data(), xmm_result_lo);
+    _mm_store_pd(dst.data() + 2, xmm_result_hi);
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_scale_vec3(ArrayBuffer<T>& dst, T scale,
+                                 const ArrayBuffer<T>& vec) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
     auto xmm_scale = _mm_set1_ps(scale);
     auto xmm_vector = _mm_load_ps(vec.data());
     auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
     _mm_store_ps(dst.data(), xmm_result);
 }
 
-TM_INLINE auto kernel_hadamard_v3f(Array3f& dst, const Array3f& lhs,
-                                   const Array3f& rhs) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_scale_vec3(ArrayBuffer<T>& dst, T scale,
+                                 const ArrayBuffer<T>& vec) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
+    auto xmm_scale = _mm_set1_pd(scale);
+    auto xmm_vector_lo = _mm_load_pd(vec.data());
+    auto xmm_vector_hi = _mm_load_pd(vec.data() + 2);
+    auto xmm_result_lo = _mm_mul_pd(xmm_scale, xmm_vector_lo);
+    auto xmm_result_hi = _mm_mul_pd(xmm_scale, xmm_vector_hi);
+    _mm_store_pd(dst.data(), xmm_result_lo);
+    _mm_store_pd(dst.data() + 2, xmm_result_hi);
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_hadamard_vec3(ArrayBuffer<T>& dst,
+                                    const ArrayBuffer<T>& lhs,
+                                    const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     _mm_store_ps(dst.data(), _mm_mul_ps(xmm_lhs, xmm_rhs));
 }
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_hadamard_vec3(ArrayBuffer<T>& dst,
+                                    const ArrayBuffer<T>& lhs,
+                                    const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
+    auto xmm_lhs_lo = _mm_load_pd(lhs.data());
+    auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);
+    auto xmm_rhs_lo = _mm_load_pd(rhs.data());
+    auto xmm_rhs_hi = _mm_load_pd(rhs.data() + 2);
+    _mm_store_pd(dst.data(), _mm_mul_pd(xmm_lhs_lo, xmm_rhs_lo));
+    _mm_store_pd(dst.data() + 2, _mm_mul_pd(xmm_lhs_hi, xmm_rhs_hi));
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_length_square_vec3(const ArrayBuffer<T>& vec) -> T {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
+    // @todo(wilbert)
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_length_square_vec3(const ArrayBuffer<T>& vec) -> T {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
+    // @todo(wilbert)
+}
+
+// ***************************************************************************//
+//   Implementations for single-precision floating point numbers (float32_t)  //
+// ***************************************************************************//
+using Vec3f = Vector3<float32_t>;
+using Array3f = Vec3f::BufferType;
 
 TM_INLINE auto kernel_length_square_v3f(const Array3f& vec) -> float32_t {
     // Implementation based on this post: https://bit.ly/3FyZF0n

--- a/include/tinymath/impl/vec3_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec3_t_sse_impl.hpp
@@ -12,15 +12,15 @@
 /**
  * SSE instruction sets required for each kernel:
  *
- * - kernel_add_v3f                 : SSE
- * - kernel_sub_v3f                 : SSE
- * - kernel_scale_v3f               : SSE
- * - kernel_hadamard_v3f            : SSE
- * - kernel_length_square_v3f       : SSE4.1 (_mm_dp_ps)
- * - kernel_length_v3f              : SSE4.1 (_mm_dp_ps)
- * - kernel_normalize_in_place_v3f  : SSE4.1 (_mm_dp_ps)
- * - kernel_dot_v3f                 : SSE4.1 (_mm_dp_ps)
- * - kernel_cross_v3f               : SSE
+ * - kernel_add_vec3                : SSE|SSE2
+ * - kernel_sub_vec3                : SSE|SSE2
+ * - kernel_scale_vec3              : SSE|SSE2
+ * - kernel_hadamard_vec3           : SSE|SSE2
+ * - kernel_length_square_vec3      : SSE|SSE2|SSE4.1 (_mm_dp_ps)
+ * - kernel_length_vec3             : SSE|SSE2|SSE4.1 (_mm_dp_ps)
+ * - kernel_normalize_in_place_vec3 : SSE|SSE2|SSE4.1 (_mm_dp_ps)
+ * - kernel_dot_vec3                : SSE|SSE2|SSE4.1 (_mm_dp_ps)
+ * - kernel_cross_vec3              : SSE
  */
 
 namespace tiny {
@@ -157,7 +157,10 @@ template <typename T,
                                   IsFloat32<T>::value>::type* = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const ArrayBuffer<T>& vec) -> T {
     static_assert(std::is_same<float, T>::value, "We must be using f32");
-    // @todo(wilbert)
+    // Implementation based on this post: https://bit.ly/3FyZF0n
+    constexpr int32_t COND_PROD_MASK = 0x71;
+    auto xmm_v = _mm_load_ps(vec.data());
+    return _mm_cvtss_f32(_mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK));
 }
 
 template <typename T,
@@ -165,30 +168,47 @@ template <typename T,
                                   IsFloat64<T>::value>::type* = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const ArrayBuffer<T>& vec) -> T {
     static_assert(std::is_same<double, T>::value, "We must be using f64");
-    // @todo(wilbert)
-}
-
-// ***************************************************************************//
-//   Implementations for single-precision floating point numbers (float32_t)  //
-// ***************************************************************************//
-using Vec3f = Vector3<float32_t>;
-using Array3f = Vec3f::BufferType;
-
-TM_INLINE auto kernel_length_square_v3f(const Array3f& vec) -> float32_t {
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x71;
-    auto xmm_v = _mm_load_ps(vec.data());
-    return _mm_cvtss_f32(_mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK));
+    constexpr int32_t COND_PROD_MASK = 0x31;
+    auto xmm_v_lo = _mm_load_pd(vec.data());
+    auto xmm_v_hi = _mm_load_pd(vec.data() + 2);
+    auto xmm_square_sum_lo = _mm_dp_pd(xmm_v_lo, xmm_v_lo, COND_PROD_MASK);
+    auto xmm_square_sum_hi = _mm_dp_pd(xmm_v_hi, xmm_v_hi, COND_PROD_MASK);
+    auto xmm_square_sum = _mm_add_pd(xmm_square_sum_lo, xmm_square_sum_hi);
+    return _mm_cvtsd_f64(xmm_square_sum);
 }
 
-TM_INLINE auto kernel_length_v3f(const Array3f& vec) -> float32_t {
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_length_vec3(const ArrayBuffer<T>& vec) -> T {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
     // Implementation based on this post: https://bit.ly/3FyZF0n
     constexpr int32_t COND_PROD_MASK = 0x71;
     auto xmm_v = _mm_load_ps(vec.data());
     return _mm_cvtss_f32(_mm_sqrt_ss(_mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK)));
 }
 
-TM_INLINE auto kernel_normalize_in_place_v3f(Array3f& vec) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_length_vec3(const ArrayBuffer<T>& vec) -> T {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
+    // Implementation based on this post: https://bit.ly/3FyZF0n
+    constexpr int32_t COND_PROD_MASK = 0x31;
+    auto xmm_v_01 = _mm_load_pd(vec.data());
+    auto xmm_v_23 = _mm_load_pd(vec.data() + 2);
+    auto xmm_square_sum_01 = _mm_dp_pd(xmm_v_01, xmm_v_01, COND_PROD_MASK);
+    auto xmm_square_sum_23 = _mm_dp_pd(xmm_v_23, xmm_v_23, COND_PROD_MASK);
+    auto xmm_square_sum = _mm_add_pd(xmm_square_sum_01, xmm_square_sum_23);
+    return _mm_cvtsd_f64(_mm_sqrt_sd(xmm_square_sum, xmm_square_sum));
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_normalize_in_place_vec3(ArrayBuffer<T>& vec) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
     // Implementation based on this post: https://bit.ly/3FyZF0n
     constexpr int32_t COND_PROD_MASK = 0x7f;
     auto xmm_v = _mm_load_ps(vec.data());
@@ -198,17 +218,59 @@ TM_INLINE auto kernel_normalize_in_place_v3f(Array3f& vec) -> void {
     _mm_store_ps(vec.data(), xmm_v_norm);
 }
 
-TM_INLINE auto kernel_dot_v3f(const Array3f& lhs, const Array3f& rhs)
-    -> float32_t {
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_normalize_in_place_vec3(ArrayBuffer<T>& vec) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
+    // Implementation based on this post: https://bit.ly/3FyZF0n
+    constexpr int32_t COND_PROD_MASK = 0x33;
+    auto xmm_v_01 = _mm_load_pd(vec.data());
+    auto xmm_v_23 = _mm_load_pd(vec.data() + 2);
+    auto xmm_sums_01 = _mm_dp_pd(xmm_v_01, xmm_v_01, COND_PROD_MASK);
+    auto xmm_sums_23 = _mm_dp_pd(xmm_v_23, xmm_v_23, COND_PROD_MASK);
+    auto xmm_r_sqrt_sums = _mm_sqrt_pd(_mm_add_pd(xmm_sums_01, xmm_sums_23));
+    auto xmm_v_norm_01 = _mm_div_pd(xmm_v_01, xmm_r_sqrt_sums);
+    auto xmm_v_norm_23 = _mm_div_pd(xmm_v_23, xmm_r_sqrt_sums);
+    _mm_store_pd(vec.data(), xmm_v_norm_01);
+    _mm_store_pd(vec.data() + 2, xmm_v_norm_23);
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_dot_vec3(const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> T {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
     constexpr int32_t COND_PROD_MASK = 0x71;
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, COND_PROD_MASK);
     return _mm_cvtss_f32(xmm_cond_prod);
-};
+}
 
-TM_INLINE auto kernel_cross_v3f(Array3f& dst, const Array3f& lhs,
-                                const Array3f& rhs) -> void {
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_dot_vec3(const ArrayBuffer<T>& lhs,
+                               const ArrayBuffer<T>& rhs) -> T {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
+    constexpr int32_t COND_PROD_MASK = 0x31;
+    auto xmm_lhs_01 = _mm_load_pd(lhs.data());
+    auto xmm_lhs_23 = _mm_load_pd(lhs.data() + 2);
+    auto xmm_rhs_01 = _mm_load_pd(rhs.data());
+    auto xmm_rhs_23 = _mm_load_pd(rhs.data() + 2);
+    auto xmm_dot_01 = _mm_dp_pd(xmm_lhs_01, xmm_rhs_01, COND_PROD_MASK);
+    auto xmm_dot_23 = _mm_dp_pd(xmm_lhs_23, xmm_rhs_23, COND_PROD_MASK);
+    return _mm_cvtsd_f64(_mm_add_pd(xmm_dot_01, xmm_dot_23));
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat32<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_cross_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                                 const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<float, T>::value, "We must be using f32");
     // Implementation adapted from @ian_mallett (https://bit.ly/3lu6pVe)
     constexpr auto MASK_A = tiny::math::ShuffleMask<3, 0, 2, 1>::value;
     constexpr auto MASK_B = tiny::math::ShuffleMask<3, 1, 0, 2>::value;
@@ -219,18 +281,31 @@ TM_INLINE auto kernel_cross_v3f(Array3f& dst, const Array3f& lhs,
     //            a[2] * b[0] - a[0] * b[2],
     //            a[0] * b[1] - a[1] * b[0],
     //                        0            ]
-    auto vec_0 = _mm_load_ps(lhs.data());  // a = {a[0], a[1], a[2], a[3]=0}
-    auto vec_1 = _mm_load_ps(rhs.data());  // b = {b[0], b[1], b[2], b[3]=0}
+    auto vec_a = _mm_load_ps(lhs.data());  // a = {a[0], a[1], a[2], a[3]=0}
+    auto vec_b = _mm_load_ps(rhs.data());  // b = {b[0], b[1], b[2], b[3]=0}
     // tmp_0 = {a[1], a[2], a[0], 0}
-    auto tmp_0 = _mm_shuffle_ps(vec_0, vec_0, MASK_A);
+    auto tmp_0 = _mm_shuffle_ps(vec_a, vec_a, MASK_A);
     // tmp_1 = {b[2], b[0], b[1], 0}
-    auto tmp_1 = _mm_shuffle_ps(vec_1, vec_1, MASK_B);
+    auto tmp_1 = _mm_shuffle_ps(vec_b, vec_b, MASK_B);
     // tmp_2 = {a[2], a[0], a[1], 0}
-    auto tmp_2 = _mm_shuffle_ps(vec_0, vec_0, MASK_B);
+    auto tmp_2 = _mm_shuffle_ps(vec_a, vec_a, MASK_B);
     // tmp_3 = {b[1], b[2], b[0], 0}
-    auto tmp_3 = _mm_shuffle_ps(vec_1, vec_1, MASK_A);
+    auto tmp_3 = _mm_shuffle_ps(vec_b, vec_b, MASK_A);
     _mm_store_ps(dst.data(), _mm_sub_ps(_mm_mul_ps(tmp_0, tmp_1),
                                         _mm_mul_ps(tmp_2, tmp_3)));
+}
+
+template <typename T,
+          typename std::enable_if<CpuHasSSE<T>::value &&
+                                  IsFloat64<T>::value>::type* = nullptr>
+TM_INLINE auto kernel_cross_vec3(ArrayBuffer<T>& dst, const ArrayBuffer<T>& lhs,
+                                 const ArrayBuffer<T>& rhs) -> void {
+    static_assert(std::is_same<double, T>::value, "We must be using f64");
+    // @todo(wilbert): so far I can't find a way that might be better than
+    // the scalar implementation (besides it might be vectorized by O3)
+    dst[0] = lhs[1] * rhs[2] - lhs[2] * rhs[1];
+    dst[1] = lhs[2] * rhs[0] - lhs[0] * rhs[2];
+    dst[2] = lhs[0] * rhs[1] - lhs[1] * rhs[0];
 }
 
 }  // namespace sse

--- a/include/tinymath/mat4_t_impl.hpp
+++ b/include/tinymath/mat4_t_impl.hpp
@@ -136,7 +136,7 @@ TM_INLINE auto operator-(const Matrix4<Scalar_T>& lhs,
     avx::kernel_sub_mat4<Scalar_T>(result.elements(), lhs.elements(),
                                    rhs.elements());
 #elif defined(TINYMATH_SSE_ENABLED)
-    sse::kernek_sub_mat4<Scalar_T>(result.elements(), lhs.elements(),
+    sse::kernel_sub_mat4<Scalar_T>(result.elements(), lhs.elements(),
                                    rhs.elements());
 #else
     scalar::kernel_sub_mat4<Scalar_T>(result.elements(), lhs.elements(),

--- a/include/tinymath/vec3_t_impl.hpp
+++ b/include/tinymath/vec3_t_impl.hpp
@@ -18,7 +18,7 @@ TM_INLINE auto squareNorm(const Vector3<T>& vec) -> T {
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert): call the related AVX implementation
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert): call the related SSE implementation
+    return sse::kernel_length_square_vec3<T>(vec.elements());
 #else
     return scalar::kernel_length_square_vec3<T>(vec.elements());
 #endif
@@ -31,7 +31,7 @@ TM_INLINE auto norm(const Vector3<T>& vec) -> T {
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert): call the related AVX implementation
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert): call the related SSE implementation
+    return sse::kernel_length_vec3<T>(vec.elements());
 #else
     return std::sqrt(scalar::kernel_length_square_vec3<T>(vec.elements()));
 #endif
@@ -45,7 +45,7 @@ TM_INLINE auto normalize(const Vector3<T>& vec) -> Vector3<T> {
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert)
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert)
+    sse::kernel_normalize_in_place_vec3<T>(vec_normalized.elements());
 #else
     scalar::kernel_normalize_in_place_vec3<T>(vec_normalized.elements());
 #endif
@@ -59,7 +59,7 @@ TM_INLINE auto normalize_in_place(Vector3<T>& vec) -> void {  // NOLINT
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert)
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert)
+    sse::kernel_normalize_in_place_vec3<T>(vec.elements());
 #else
     scalar::kernel_normalize_in_place_vec3<T>(vec.elements());
 #endif
@@ -72,7 +72,7 @@ TM_INLINE auto dot(const Vector3<T>& lhs, const Vector3<T>& rhs) -> T {
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert)
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert)
+    return sse::kernel_dot_vec3<T>(lhs.elements(), rhs.elements());
 #else
     return scalar::kernel_dot_vec3<T>(lhs.elements(), rhs.elements());
 #endif
@@ -87,7 +87,8 @@ TM_INLINE auto cross(const Vector3<T>& lhs, const Vector3<T>& rhs)
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert)
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert)
+    sse::kernel_cross_vec3<T>(vec_cross.elements(), lhs.elements(),
+                              rhs.elements());
 #else
     scalar::kernel_cross_vec3<T>(vec_cross.elements(), lhs.elements(),
                                  rhs.elements());
@@ -115,7 +116,8 @@ TM_INLINE auto operator+(const Vector3<T>& lhs, const Vector3<T>& rhs)
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert)
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert)
+    sse::kernel_add_vec3<T>(vec_result.elements(), lhs.elements(),
+                            rhs.elements());
 #else
     scalar::kernel_add_vec3<T>(vec_result.elements(), lhs.elements(),
                                rhs.elements());
@@ -143,7 +145,8 @@ TM_INLINE auto operator-(const Vector3<T>& lhs, const Vector3<T>& rhs)
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert)
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert)
+    sse::kernel_sub_vec3<T>(vec_result.elements(), lhs.elements(),
+                            rhs.elements());
 #else
     scalar::kernel_sub_vec3<T>(vec_result.elements(), lhs.elements(),
                                rhs.elements());
@@ -170,7 +173,7 @@ TM_INLINE auto operator*(T scale, const Vector3<T>& vec) -> Vector3<T> {
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert)
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert)
+    sse::kernel_scale_vec3<T>(vec_result.elements(), scale, vec.elements());
 #else
     scalar::kernel_scale_vec3<T>(vec_result.elements(), scale, vec.elements());
 #endif
@@ -196,7 +199,7 @@ TM_INLINE auto operator*(const Vector3<T>& vec, T scale) -> Vector3<T> {
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert)
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert)
+    sse::kernel_scale_vec3<T>(vec_result.elements(), scale, vec.elements());
 #else
     scalar::kernel_scale_vec3(vec_result.elements(), scale, vec.elements());
 #endif
@@ -223,7 +226,8 @@ TM_INLINE auto operator*(const Vector3<T>& lhs, const Vector3<T>& rhs)
 #if defined(TINYMATH_AVX_ENABLED)
     // @todo(wilbert)
 #elif defined(TINYMATH_SSE_ENABLED)
-    // @todo(wilbert)
+    sse::kernel_hadamard_vec3<T>(vec_result.elements(), lhs.elements(),
+                                 rhs.elements());
 #else
     scalar::kernel_hadamard_vec3<T>(vec_result.elements(), lhs.elements(),
                                     rhs.elements());

--- a/include/tinymath/vec3_t_impl.hpp
+++ b/include/tinymath/vec3_t_impl.hpp
@@ -1,363 +1,271 @@
 #pragma once
 
 // clang-format off
-#include <ios>
-#include <cmath>
-#include <string>
-#include <cassert>
-#include <algorithm>
-#include <type_traits>
-
+#include <tinymath/vec3_t.hpp>
 #include <tinymath/impl/vec3_t_scalar_impl.hpp>
-
-#if defined(TINYMATH_SSE_ENABLED)
 #include <tinymath/impl/vec3_t_sse_impl.hpp>
-#endif
-
-#if defined(TINYMATH_AVX_ENABLED)
 #include <tinymath/impl/vec3_t_avx_impl.hpp>
-#endif
+#include <type_traits>
 // clang-format on
 
 namespace tiny {
 namespace math {
 
-template <typename Scalar_T>
-auto operator<<(std::ostream& output_stream, const Vector3<Scalar_T>& src)
-    -> std::ostream& {
-    output_stream << "(" << src.x() << ", " << src.y() << ", " << src.z()
-                  << ")";
-    return output_stream;
-}
-
-template <typename Scalar_T>
-auto operator>>(std::istream& input_stream, Vector3<Scalar_T>& dst)
-    -> std::istream& {
-    // Based on ignition-math implementation https://bit.ly/3iqAVgS
-    Scalar_T x{};
-    Scalar_T y{};
-    Scalar_T z{};
-
-    input_stream.setf(std::ios_base::skipws);
-    input_stream >> x >> y >> z;
-    if (!input_stream.fail()) {
-        dst.x() = x;
-        dst.y() = y;
-        dst.z() = z;
-    }
-
-    return input_stream;
-}
-
-template <typename Scalar_T>
-Vector3<Scalar_T>::Vector3(Scalar_T x) {
-    m_Elements[0] = x;
-    m_Elements[1] = x;
-    m_Elements[2] = x;
-    m_Elements[3] = 0;
-}
-
-template <typename Scalar_T>
-Vector3<Scalar_T>::Vector3(Scalar_T x, Scalar_T y) {
-    m_Elements[0] = x;
-    m_Elements[1] = y;
-    m_Elements[2] = y;
-    m_Elements[3] = 0;
-}
-
-template <typename Scalar_T>
-Vector3<Scalar_T>::Vector3(Scalar_T x, Scalar_T y, Scalar_T z) {
-    m_Elements[0] = x;
-    m_Elements[1] = y;
-    m_Elements[2] = z;
-    m_Elements[3] = 0;
-}
-
-template <typename Scalar_T>
-Vector3<Scalar_T>::Vector3(const std::initializer_list<Scalar_T>& values) {
-    // Complain in case we don't receive exactly 3 values
-    assert(values.size() == Vector3<Scalar_T>::VECTOR_NDIM);
-    // Just copy the whole data from the initializer list
-    std::copy(values.begin(), values.end(), m_Elements.data());
-}
-
-template <typename Scalar_T>
-auto Vector3<Scalar_T>::toString() const -> std::string {
-    std::stringstream str_result;
-    if (std::is_same<ElementType, float>()) {
-        str_result << "Vector3f(" << x() << ", " << y() << ", " << z() << ")";
-    } else if (std::is_same<ElementType, double>()) {
-        str_result << "Vector3d(" << x() << ", " << y() << ", " << z() << ")";
-    } else {
-        str_result << "Vector3X(" << x() << ", " << y() << ", " << z() << ")";
-    }
-    return str_result.str();
-}
-
-// ***************************************************************************//
-//     Specializations for single-precision floating numbers (float32_t)      //
-// ***************************************************************************//
-using Vec3f = Vector3<float32_t>;
-
-template <>
-TM_INLINE auto Vec3f::squaredNorm() const -> float32_t {
-#if defined(TINYMATH_SSE_ENABLED)
-    return sse::kernel_length_square_v3f(elements());
-#else
-    return scalar::kernel_length_square_v3f(elements());
-#endif
-}
-
-template <>
-TM_INLINE auto Vec3f::norm() const -> float32_t {
-#if defined(TINYMATH_SSE_ENABLED)
-    return sse::kernel_length_v3f(elements());
-#else
-    return std::sqrt(scalar::kernel_length_square_v3f(elements()));
-#endif
-}
-
-template <>
-TM_INLINE auto Vec3f::normalize() -> void {
-#if defined(TINYMATH_SSE_ENABLED)
-    sse::kernel_normalize_in_place_v3f(elements());
-#else
-    scalar::kernel_normalize_in_place_v3f(elements());
-#endif
-}
-
-template <>
-TM_INLINE auto Vec3f::normalized() const -> Vec3f {
-    auto result = *this;
-#if defined(TINYMATH_SSE_ENABLED)
-    sse::kernel_normalize_in_place_v3f(result.elements());
-#else
-    scalar::kernel_normalize_in_place_v3f(result.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto Vec3f::dot(const Vec3f& other) const -> float32_t {
-#if defined(TINYMATH_SSE_ENABLED)
-    return sse::kernel_dot_v3f(elements(), other.elements());
-#else
-    return scalar::kernel_dot_v3f(elements(), other.elements());
-#endif
-}
-
-template <>
-TM_INLINE auto Vec3f::cross(const Vec3f& other) const -> Vec3f {
-    Vec3f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    sse::kernel_cross_v3f(result.elements(), elements(), other.elements());
-#else
-    scalar::kernel_cross_v3f(result.elements(), elements(), other.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator+(const Vec3f& lhs, const Vec3f& rhs) -> Vec3f {
-    Vec3f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    // SSE allows SIMD addition of 4-float packed vectors, so we use it here
-    sse::kernel_add_v3f(result.elements(), lhs.elements(), rhs.elements());
-#else
-    // Use scalar version for all other cases (AVX registers require 8-floats)
-    scalar::kernel_add_v3f(result.elements(), lhs.elements(), rhs.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator-(const Vec3f& lhs, const Vec3f& rhs) -> Vec3f {
-    Vec3f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    // SSE allows SIMD substraction of 4-float packed vectors, so we use it here
-    sse::kernel_sub_v3f(result.elements(), lhs.elements(), rhs.elements());
-#else
-    // Use scalar version for all other cases (AVX registers require 8-floats)
-    scalar::kernel_sub_v3f(result.elements(), lhs.elements(), rhs.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator*(float32_t scale, const Vec3f& vec) -> Vec3f {
-    Vec3f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    sse::kernel_scale_v3f(result.elements(), scale, vec.elements());
-#else
-    scalar::kernel_scale_v3f(result.elements(), scale, vec.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator*(const Vec3f& vec, float32_t scale) -> Vec3f {
-    Vec3f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    sse::kernel_scale_v3f(result.elements(), scale, vec.elements());
-#else
-    scalar::kernel_scale_v3f(result.elements(), scale, vec.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator*(const Vec3f& lhs, const Vec3f& rhs) -> Vec3f {
-    Vec3f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    sse::kernel_hadamard_v3f(result.elements(), lhs.elements(), rhs.elements());
-#else
-    scalar::kernel_hadamard_v3f(result.elements(), lhs.elements(),
-                                rhs.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator==(const Vec3f& lhs, const Vec3f& rhs) -> bool {
-    return scalar::kernel_compare_eq_v3f(lhs.elements(), rhs.elements());
-}
-
-template <>
-TM_INLINE auto operator!=(const Vec3f& lhs, const Vec3f& rhs) -> bool {
-    return !scalar::kernel_compare_eq_v3f(lhs.elements(), rhs.elements());
-}
-
-// ***************************************************************************//
-//     Specializations for double-precision floating numbers (float64_t)      //
-// ***************************************************************************//
-using Vec3d = Vector3<float64_t>;
-
-template <>
-TM_INLINE auto Vec3d::squaredNorm() const -> float64_t {
+/// \brief Returns the square of the norm-2 of the vector
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto squareNorm(const Vector3<T>& vec) -> T {
 #if defined(TINYMATH_AVX_ENABLED)
-    return avx::kernel_length_square_v3d(elements());
+    // @todo(wilbert): call the related AVX implementation
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert): call the related SSE implementation
 #else
-    return scalar::kernel_length_square_v3d(elements());
+    return scalar::kernel_length_square_vec3<T>(vec.elements());
 #endif
 }
 
-template <>
-TM_INLINE auto Vec3d::norm() const -> float64_t {
+/// \brief Returns the norm-2 of the vector
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto norm(const Vector3<T>& vec) -> T {
 #if defined(TINYMATH_AVX_ENABLED)
-    return avx::kernel_length_v3d(elements());
+    // @todo(wilbert): call the related AVX implementation
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert): call the related SSE implementation
 #else
-    return std::sqrt(scalar::kernel_length_square_v3d(elements()));
+    return std::sqrt(scalar::kernel_length_square_vec3<T>(vec.elements()));
 #endif
 }
 
-template <>
-TM_INLINE auto Vec3d::normalize() -> void {
+/// \brief Returns a normalized version of this vector
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto normalize(const Vector3<T>& vec) -> Vector3<T> {
+    Vector3<T> vec_normalized = vec;
 #if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_normalize_in_place_v3d(elements());
+    // @todo(wilbert)
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert)
 #else
-    scalar::kernel_normalize_in_place_v3d(elements());
+    scalar::kernel_normalize_in_place_vec3<T>(vec_normalized.elements());
 #endif
+    return vec_normalized;
 }
 
-template <>
-TM_INLINE auto Vec3d::normalized() const -> Vec3d {
-    auto result = *this;
+/// \brief Normalizes in-place the given vector
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto normalize_in_place(Vector3<T>& vec) -> void {  // NOLINT
 #if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_normalize_in_place_v3d(result.elements());
+    // @todo(wilbert)
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert)
 #else
-    scalar::kernel_normalize_in_place_v3d(result.elements());
+    scalar::kernel_normalize_in_place_vec3<T>(vec.elements());
 #endif
-    return result;
 }
 
-template <>
-TM_INLINE auto Vec3d::dot(const Vec3d& other) const -> float64_t {
+/// \brief Returns the dot-product of the given two vectors
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto dot(const Vector3<T>& lhs, const Vector3<T>& rhs) -> T {
 #if defined(TINYMATH_AVX_ENABLED)
-    return avx::kernel_dot_v3d(elements(), other.elements());
+    // @todo(wilbert)
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert)
 #else
-    return scalar::kernel_dot_v3d(elements(), other.elements());
+    return scalar::kernel_dot_vec3<T>(lhs.elements(), rhs.elements());
 #endif
 }
 
-template <>
-TM_INLINE auto Vec3d::cross(const Vec3d& other) const -> Vec3d {
-    Vec3d result;
+/// \brief Returns the cross-product of the given two vectors
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto cross(const Vector3<T>& lhs, const Vector3<T>& rhs)
+    -> Vector3<T> {
+    Vector3<T> vec_cross;
 #if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_cross_v3d(result.elements(), elements(), other.elements());
+    // @todo(wilbert)
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert)
 #else
-    scalar::kernel_cross_v3d(result.elements(), elements(), other.elements());
+    scalar::kernel_cross_vec3<T>(vec_cross.elements(), lhs.elements(),
+                                 rhs.elements());
 #endif
-    return result;
+    return vec_cross;
 }
 
-template <>
-TM_INLINE auto operator+(const Vec3d& lhs, const Vec3d& rhs) -> Vec3d {
-    Vec3d result;
+/// \brief Returns the vector-sum of two 3d vector operands
+///
+/// \tparam T Type of scalar value used for the 3d-vector operands
+///
+/// This operator implements an element-wise sum of two Vector3 operands given
+/// as input arguments. The internal operator selects the appropriate "kernel"
+/// (just a function) to which to call, depending on whether or not the library
+/// was compiled using SIMD support (i.e. SSE and AVX function intrinsics will
+/// be used to handle the operation).
+///
+/// \param[in] lhs Left-hand-side operand of the vector-sum
+/// \param[in] rhs Right-hand-side operand of the vector-sum
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto operator+(const Vector3<T>& lhs, const Vector3<T>& rhs)
+    -> Vector3<T> {
+    Vector3<T> vec_result;
 #if defined(TINYMATH_AVX_ENABLED)
-    // AVX allows SIMD addition of 4-double packed vectors, so we use it
-    avx::kernel_add_v3d(result.elements(), lhs.elements(), rhs.elements());
+    // @todo(wilbert)
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert)
 #else
-    // Use scalar version for all other cases, SSE register width is not enough
-    scalar::kernel_add_v3d(result.elements(), lhs.elements(), rhs.elements());
+    scalar::kernel_add_vec3<T>(vec_result.elements(), lhs.elements(),
+                               rhs.elements());
 #endif
-    return result;
+    return vec_result;
 }
 
-template <>
-TM_INLINE auto operator-(const Vec3d& lhs, const Vec3d& rhs) -> Vec3d {
-    Vec3d result;
+/// \brief Returns the vector-difference of two 3d vector operands
+///
+/// \tparam T Type of scalar value used for the 3d-vector operands
+///
+/// This operator implements an element-wise difference of two Vector3 operands
+/// given as input arguments. The internal operator selects the appropriate
+/// "kernel" (just a function) to which to call, depending on whether or not the
+/// library was compiled using SIMD support (i.e. SSE and AVX function
+/// intrinsics will be used to handle the operation).
+///
+/// \param[in] lhs Left-hand-side operand of the vector-sum
+/// \param[in] rhs Right-hand-side operand of the vector-sum
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto operator-(const Vector3<T>& lhs, const Vector3<T>& rhs)
+    -> Vector3<T> {
+    Vector3<T> vec_result;
 #if defined(TINYMATH_AVX_ENABLED)
-    // AVX allows SIMD substraction of 4-double packed vectors, so we use it
-    avx::kernel_sub_v3d(result.elements(), lhs.elements(), rhs.elements());
+    // @todo(wilbert)
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert)
 #else
-    // Use scalar version for all other cases, SSE register width is not enough
-    scalar::kernel_sub_v3d(result.elements(), lhs.elements(), rhs.elements());
+    scalar::kernel_sub_vec3<T>(vec_result.elements(), lhs.elements(),
+                               rhs.elements());
 #endif
-    return result;
+    return vec_result;
 }
 
-template <>
-TM_INLINE auto operator*(float64_t scale, const Vec3d& vec) -> Vec3d {
-    Vec3d result;
+/// \brief Returns the scalar-vector product of a scalar and 3d vector operands
+///
+/// \tparam T Type of scalar used by both scalar and vector operands
+///
+/// This operator implements the scalar-vector product of two operands (a scalar
+/// and a vector in that order) given as input arguments. The internal operator
+/// selects the appropriate "kernel" (just a function) to which to call,
+/// depending on whether or not the library was compiled using SIMD support
+/// (i.e. SSE and AVX function intrinsics will be used to handle the operation).
+///
+/// \param[in] scale Scalar value by which to scale the second operand
+/// \param[in] vec Vector in 3d-space which we want to scale
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto operator*(T scale, const Vector3<T>& vec) -> Vector3<T> {
+    Vector3<T> vec_result;
 #if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_scale_v3d(result.elements(), scale, vec.elements());
+    // @todo(wilbert)
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert)
 #else
-    scalar::kernel_scale_v3d(result.elements(), scale, vec.elements());
+    scalar::kernel_scale_vec3<T>(vec_result.elements(), scale, vec.elements());
 #endif
-    return result;
+    return vec_result;
 }
 
-template <>
-TM_INLINE auto operator*(const Vec3d& vec, float64_t scale) -> Vec3d {
-    Vec3d result;
+/// \brief Returns the vector-scalar product of a 3d vector and scalar operands
+///
+/// \tparam T Type of scalar used by both vector and scalar operands
+///
+/// This operator implements the vector-scalar product of two operands (a vector
+/// and a scalar in that order) given as input arguments. The internal operator
+/// selects the appropriate "kernel" (just a function) to which to call,
+/// depending on whether or not the library was compiled using SIMD support
+/// (i.e. SSE and AVX function intrinsics will be used to handle the operation).
+///
+/// \param[in] vec Vector in 3d-space which we want to scale
+/// \param[in] scale Scalar value by which to scale the first operand
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto operator*(const Vector3<T>& vec, T scale) -> Vector3<T> {
+    Vector3<T> vec_result;
 #if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_scale_v3d(result.elements(), scale, vec.elements());
+    // @todo(wilbert)
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert)
 #else
-    scalar::kernel_scale_v3d(result.elements(), scale, vec.elements());
+    scalar::kernel_scale_vec3(vec_result.elements(), scale, vec.elements());
 #endif
-    return result;
+    return vec_result;
 }
 
-template <>
-TM_INLINE auto operator*(const Vec3d& lhs, const Vec3d& rhs) -> Vec3d {
-    Vec3d result;
+/// \brief Returns the element-wise product of two 3d vector operands
+///
+/// \tparam T Type of scalar value used by the 3d-vector operands
+///
+/// This operator implements an element-wise product (Hadamard-Schur product) of
+/// two Vector3 operands given as input arguments. The internal operator selects
+/// the appropriate "kernel" (just a function) to which to call, depending on
+/// whether or not the library was compiled using SIMD support (i.e. SSE and AVX
+/// function intrinsics will be used to handle the operation).
+///
+/// \param[in] lhs Left-hand-side operand of the element-wise product
+/// \param[in] rhs Right-hand-side operand of the element-wise product
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto operator*(const Vector3<T>& lhs, const Vector3<T>& rhs)
+    -> Vector3<T> {
+    Vector3<T> vec_result;
 #if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_hadamard_v3d(result.elements(), lhs.elements(), rhs.elements());
+    // @todo(wilbert)
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert)
 #else
-    scalar::kernel_hadamard_v3d(result.elements(), lhs.elements(),
-                                rhs.elements());
+    scalar::kernel_hadamard_vec3<T>(vec_result.elements(), lhs.elements(),
+                                    rhs.elements());
 #endif
-    return result;
+    return vec_result;
 }
 
-template <>
-TM_INLINE auto operator==(const Vec3d& lhs, const Vec3d& rhs) -> bool {
-    return scalar::kernel_compare_eq_v3d(lhs.elements(), rhs.elements());
+/// \brief Checks if two given vectors are "equal" (within epsilon margin)
+///
+/// \tparam T Type of scalar value used by the 3d-vector operands
+///
+/// This operator implements an "np.allclose"-like operation (numpy's allclose
+/// function), checking if the corresponding (x,y,z) entries of both operands
+/// are within a certain margin "epsilon" (pre-defined constant). There was an
+/// "equal"-like SIMD instruction that implements floating point comparisons,
+/// however, we're not using it as single-precision floating point operations
+/// and transformation functions within the library might result in compounding
+/// errors that the user might want to test a small margin of error tuned
+/// appropriately (specially for single-precision floating point types)
+///
+/// \param[in] lhs Left-hand-side operand of the comparison
+/// \param[in] rhs Right-hand-side operand of the comparison
+/// \returns true if the given vectors are within a pre-defined epsilon margin
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto operator==(const Vector3<T>& lhs, const Vector3<T>& rhs)
+    -> bool {
+    return scalar::kernel_compare_eq_vec3<T>(lhs.elements(), rhs.elements());
 }
 
-template <>
-TM_INLINE auto operator!=(const Vec3d& lhs, const Vec3d& rhs) -> bool {
-    return !scalar::kernel_compare_eq_v3d(lhs.elements(), rhs.elements());
+/// \brief Checks if two given vectors are not "equal" (within epsilon margin)
+///
+/// \tparam T Type of scalar value used by the 3d-vector operands
+///
+/// \param[in] lhs Left-hand-side operand of the comparison
+/// \param[in] rhs Right-hand-side operand of the comparison
+/// \returns true if the given vectors are not within a pre-defined margin
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+TM_INLINE auto operator!=(const Vector3<T>& lhs, const Vector3<T>& rhs)
+    -> bool {
+    return !scalar::kernel_compare_eq_vec3<T>(lhs.elements(), rhs.elements());
 }
 
 }  // namespace math

--- a/tests/cpp/test_vec3_operations.cpp
+++ b/tests/cpp/test_vec3_operations.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch.hpp>
-#include <cmath>
 #include <tinymath/tinymath.hpp>
 
 /*
@@ -140,8 +139,8 @@ TEMPLATE_TEST_CASE("Vector3 class (vec3_t) core Operations", "[vec3_t][ops]",
         auto length_square = val_x * val_x + val_y * val_y + val_z * val_z;
         auto length = std::sqrt(length_square);
 
-        auto v_length_square = v.squaredNorm();
-        auto v_length = v.norm();
+        auto v_length_square = tiny::math::squareNorm(v);
+        auto v_length = tiny::math::norm(v);
 
         REQUIRE(std::abs(v_length_square - length_square) < EPSILON);
         REQUIRE(std::abs(v_length - length) < EPSILON);
@@ -152,14 +151,14 @@ TEMPLATE_TEST_CASE("Vector3 class (vec3_t) core Operations", "[vec3_t][ops]",
         auto val_y = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);  // NOLINT
         auto val_z = GENERATE(as<T>{}, 3.0, 5.0, 7.0, 9.0);  // NOLINT
         Vector3 v(val_x, val_y, val_z);
-        v.normalize();
+        tiny::math::normalize_in_place(v);
 
         auto norm = std::sqrt(val_x * val_x + val_y * val_y + val_z * val_z);
         auto val_xnorm = val_x / norm;
         auto val_ynorm = val_y / norm;
         auto val_znorm = val_z / norm;
 
-        auto v_norm = v.norm();
+        auto v_norm = tiny::math::norm(v);
 
         REQUIRE(std::abs(v_norm - 1.0) < EPSILON);
         REQUIRE(std::abs(v.x() - val_xnorm) < EPSILON);
@@ -172,14 +171,14 @@ TEMPLATE_TEST_CASE("Vector3 class (vec3_t) core Operations", "[vec3_t][ops]",
         auto val_y = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);  // NOLINT
         auto val_z = GENERATE(as<T>{}, 3.0, 5.0, 7.0, 9.0);  // NOLINT
         Vector3 v(val_x, val_y, val_z);
-        auto vn = v.normalized();
+        auto vn = tiny::math::normalize(v);
 
         auto norm = std::sqrt(val_x * val_x + val_y * val_y + val_z * val_z);
         auto val_xnorm = val_x / norm;
         auto val_ynorm = val_y / norm;
         auto val_znorm = val_z / norm;
 
-        auto vn_norm = vn.norm();
+        auto vn_norm = tiny::math::norm(vn);
 
         REQUIRE(std::abs(vn_norm - 1.0) < EPSILON);
         REQUIRE(std::abs(vn.x() - val_xnorm) < EPSILON);
@@ -200,7 +199,7 @@ TEMPLATE_TEST_CASE("Vector3 class (vec3_t) core Operations", "[vec3_t][ops]",
         Vector3 v_b(val_x_b, val_y_b, val_z_b);
 
         auto dot = val_x_a * val_x_b + val_y_a * val_y_b + val_z_a * val_z_b;
-        auto v_dot = v_a.dot(v_b);
+        auto v_dot = tiny::math::dot(v_a, v_b);
 
         REQUIRE(std::abs(v_dot - dot) < EPSILON);
     }
@@ -212,9 +211,9 @@ TEMPLATE_TEST_CASE("Vector3 class (vec3_t) core Operations", "[vec3_t][ops]",
             Vector3 v_j(0.0, 1.0, 0.0);
             Vector3 v_k(0.0, 0.0, 1.0);
 
-            auto v_ij = v_i.cross(v_j);
-            auto v_jk = v_j.cross(v_k);
-            auto v_ki = v_k.cross(v_i);
+            auto v_ij = tiny::math::cross(v_i, v_j);
+            auto v_jk = tiny::math::cross(v_j, v_k);
+            auto v_ki = tiny::math::cross(v_k, v_i);
 
             // i x j = k
             REQUIRE(std::abs(v_ij.x() - 0.0) < EPSILON);
@@ -238,7 +237,7 @@ TEMPLATE_TEST_CASE("Vector3 class (vec3_t) core Operations", "[vec3_t][ops]",
             Vector3 v_b(4.0, 5.0, 6.0);  // NOLINT
             Vector3 v_c(7.0, 8.0, 9.0);  // NOLINT
 
-            auto result = v_a.cross(v_b) + v_c;
+            auto result = tiny::math::cross(v_a, v_b) + v_c;
             REQUIRE(std::abs(result.x() - 4.0) < EPSILON);   // NOLINT
             REQUIRE(std::abs(result.y() - 14.0) < EPSILON);  // NOLINT
             REQUIRE(std::abs(result.z() - 6.0) < EPSILON);   // NOLINT


### PR DESCRIPTION
# Description

Currently we have quite a lot of duplicated code for f32 and f64 on vec3 types, which can be simplified by using [`SFINAE`][0], as it was for mat4 types.

## Checklist|Tasks

- [ ] `SFINAE` vec3 API (refactor operators usage)
- [ ] `SFINAE` for Scalar-kernels
- [ ] `SFINAE` for SSE-kernels
- [ ] `SFINAE` for AVX-kernels

[0]: <https://en.cppreference.com/w/cpp/language/sfinae> (sfinae-cpp-reference)
