### PR TITLE
Refactor vec4 types using SFINAE

### DIFF
--- a/include/tinymath/impl/vec4_t_scalar_impl.hpp
+++ b/include/tinymath/impl/vec4_t_scalar_impl.hpp
@@ -6,104 +6,65 @@ namespace tiny {
 namespace math {
 namespace scalar {
 
-// ***************************************************************************//
-//   Implementations for single-precision floating point numbers (float32_t)  //
-// ***************************************************************************//
-using Vec4f = Vector4<float32_t>;
-using Array4f = Vec4f::BufferType;
+template <typename T>
+using Vec4Buffer = typename Vector4<T>::BufferType;
 
-TM_INLINE auto kernel_add_v4f(Array4f& dst, const Array4f& lhs,
-                              const Array4f& rhs) -> void {
-    for (int32_t i = 0; i < Vec4f::VECTOR_NDIM; ++i) {
+template <typename T>
+using SFINAE_VEC4_SCALAR_GUARD =
+    typename std::enable_if<IsScalar<T>::value>::type*;
+
+template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
+                               const Vec4Buffer<T>& rhs) -> void {
+    for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] + rhs[i];
     }
 }
 
-TM_INLINE auto kernel_sub_v4f(Array4f& dst, const Array4f& lhs,
-                              const Array4f& rhs) -> void {
-    for (int32_t i = 0; i < Vec4f::VECTOR_NDIM; ++i) {
+template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
+                               const Vec4Buffer<T>& rhs) -> void {
+    for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] - rhs[i];
     }
 }
 
-TM_INLINE auto kernel_scale_v4f(Array4f& dst, float32_t scale,
-                                const Array4f& vec) -> void {
-    for (int32_t i = 0; i < Vec4f::VECTOR_NDIM; ++i) {
+template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_scale_vec4(Vec4Buffer<T>& dst, T scale,
+                                 const Vec4Buffer<T>& vec) -> void {
+    for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         dst[i] = scale * vec[i];
     }
 }
 
-TM_INLINE auto kernel_hadamard_v4f(Array4f& dst, const Array4f& lhs,
-                                   const Array4f& rhs) -> void {
-    for (int32_t i = 0; i < Vec4f::VECTOR_NDIM; ++i) {
+template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_hadamard_vec4(Vec4Buffer<T>& dst,
+                                    const Vec4Buffer<T>& lhs,
+                                    const Vec4Buffer<T>& rhs) -> void {
+    for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] * rhs[i];
     }
 }
 
-TM_INLINE auto kernel_dot_v4f(const Array4f& lhs, const Array4f& rhs)
-    -> float32_t {
-    return lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2] +
-           lhs[3] * rhs[3];
-}
-
-TM_INLINE auto kernel_compare_eq_v4f(const Array4f& lhs, const Array4f& rhs)
-    -> bool {
-    // Check all-close within an epsilon (EPS)
-    constexpr auto EPSILON = tiny::math::EPS<float32_t>;
-    return (std::abs(lhs[0] - rhs[0]) < EPSILON) &&
-           (std::abs(lhs[1] - rhs[1]) < EPSILON) &&
-           (std::abs(lhs[2] - rhs[2]) < EPSILON) &&
-           (std::abs(lhs[3] - rhs[3]) < EPSILON);
-}
-
-// ***************************************************************************//
-//   Implementations for double-precision floating point numbers (float64_t)  //
-// ***************************************************************************//
-using Vec4d = Vector4<float64_t>;
-using Array4d = Vec4d::BufferType;
-
-TM_INLINE auto kernel_add_v4d(Array4d& dst, const Array4d& lhs,
-                              const Array4d& rhs) -> void {
-    for (int32_t i = 0; i < Vec4d::VECTOR_NDIM; ++i) {
-        dst[i] = lhs[i] + rhs[i];
+template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
+                               const Vec4Buffer<T>& rhs) -> T {
+    T accum = static_cast<T>(0.0);
+    for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
+        accum += lhs[i] * rhs[i];
     }
+    return accum;
 }
 
-TM_INLINE auto kernel_sub_v4d(Array4d& dst, const Array4d& lhs,
-                              const Array4d& rhs) -> void {
-    for (int32_t i = 0; i < Vec4d::VECTOR_NDIM; ++i) {
-        dst[i] = lhs[i] - rhs[i];
+template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_compare_eq_vec4(const Vec4Buffer<T>& lhs,
+                                      const Vec4Buffer<T>& rhs) -> bool {
+    for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
+        if (std::abs(lhs[i] - rhs[i]) >= tiny::math::EPS<T>) {
+            return false;
+        }
     }
-}
-
-TM_INLINE auto kernel_scale_v4d(Array4d& dst, float64_t scale,
-                                const Array4d& vec) -> void {
-    for (int32_t i = 0; i < Vec4d::VECTOR_NDIM; ++i) {
-        dst[i] = scale * vec[i];
-    }
-}
-
-TM_INLINE auto kernel_hadamard_v4d(Array4d& dst, const Array4d& lhs,
-                                   const Array4d& rhs) -> void {
-    for (int32_t i = 0; i < Vec4d::VECTOR_NDIM; ++i) {
-        dst[i] = lhs[i] * rhs[i];
-    }
-}
-
-TM_INLINE auto kernel_dot_v4d(const Array4d& lhs, const Array4d& rhs)
-    -> float64_t {
-    return lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2] +
-           lhs[3] * rhs[3];
-}
-
-TM_INLINE auto kernel_compare_eq_v4d(const Array4d& lhs, const Array4d& rhs)
-    -> bool {
-    // Check all-close within an epsilon (EPS)
-    constexpr auto EPSILON = tiny::math::EPS<float64_t>;
-    return (std::abs(lhs[0] - rhs[0]) < EPSILON) &&
-           (std::abs(lhs[1] - rhs[1]) < EPSILON) &&
-           (std::abs(lhs[2] - rhs[2]) < EPSILON) &&
-           (std::abs(lhs[3] - rhs[3]) < EPSILON);
+    return true;
 }
 
 }  // namespace scalar

--- a/include/tinymath/vec4_t_impl.hpp
+++ b/include/tinymath/vec4_t_impl.hpp
@@ -1,277 +1,192 @@
 #pragma once
 
 // clang-format off
-#include <ios>
-#include <cmath>
-#include <string>
-#include <algorithm>
-#include <type_traits>
-
+#include <tinymath/vec4_t.hpp>
 #include <tinymath/impl/vec4_t_scalar_impl.hpp>
-
-#if defined(TINYMATH_SSE_ENABLED)
 #include <tinymath/impl/vec4_t_sse_impl.hpp>
-#endif
-
-#if defined(TINYMATH_AVX_ENABLED)
 #include <tinymath/impl/vec4_t_avx_impl.hpp>
-#endif
 // clang-format on
 
 namespace tiny {
 namespace math {
 
-template <typename Scalar_T>
-auto operator<<(std::ostream& output_stream, const Vector4<Scalar_T>& src)
-    -> std::ostream& {
-    output_stream << "(" << src.x() << ", " << src.y() << ", " << src.z()
-                  << ", " << src.w() << ")";
-    return output_stream;
-}
+template <typename T>
+using SFINAE_VEC4_GUARD = typename std::enable_if<IsScalar<T>::value>::type*;
 
-template <typename Scalar_T>
-auto operator>>(std::istream& input_stream, Vector4<Scalar_T>& dst)
-    -> std::istream& {
-    // Based on ignition-math implementation https://bit.ly/3iqAVgS
-    Scalar_T x{};
-    Scalar_T y{};
-    Scalar_T z{};
-    Scalar_T w{};
-
-    input_stream.setf(std::ios_base::skipws);
-    input_stream >> x >> y >> z >> w;
-    if (!input_stream.fail()) {
-        dst.x() = x;
-        dst.y() = y;
-        dst.z() = z;
-        dst.w() = w;
-    }
-
-    return input_stream;
-}
-
-template <typename Scalar_T>
-Vector4<Scalar_T>::Vector4(Scalar_T x) {
-    m_Elements[0] = x;
-    m_Elements[1] = x;
-    m_Elements[2] = x;
-    m_Elements[3] = x;
-}
-
-template <typename Scalar_T>
-Vector4<Scalar_T>::Vector4(Scalar_T x, Scalar_T y) {
-    m_Elements[0] = x;
-    m_Elements[1] = y;
-    m_Elements[2] = y;
-    m_Elements[3] = y;
-}
-
-template <typename Scalar_T>
-Vector4<Scalar_T>::Vector4(Scalar_T x, Scalar_T y, Scalar_T z) {
-    m_Elements[0] = x;
-    m_Elements[1] = y;
-    m_Elements[2] = z;
-    m_Elements[3] = z;
-}
-
-template <typename Scalar_T>
-Vector4<Scalar_T>::Vector4(Scalar_T x, Scalar_T y, Scalar_T z, Scalar_T w) {
-    m_Elements[0] = x;
-    m_Elements[1] = y;
-    m_Elements[2] = z;
-    m_Elements[3] = w;
-}
-
-template <typename Scalar_T>
-Vector4<Scalar_T>::Vector4(const std::initializer_list<Scalar_T>& values) {
-    // Complain in case we don't receive exactly 4 values
-    assert(values.size() == Vector4<Scalar_T>::VECTOR_NDIM);
-    // Just copy the whole data from the initializer list
-    std::copy(values.begin(), values.end(), m_Elements.data());
-}
-
-template <typename Scalar_T>
-auto Vector4<Scalar_T>::toString() const -> std::string {
-    std::stringstream str_result;
-    if (std::is_same<ElementType, float>()) {
-        str_result << "Vector4f(" << x() << ", " << y() << ", " << z() << ", "
-                   << w() << ")";
-    } else if (std::is_same<ElementType, double>()) {
-        str_result << "Vector4d(" << x() << ", " << y() << ", " << z() << ", "
-                   << w() << ")";
-    } else {
-        str_result << "Vector4X(" << x() << ", " << y() << ", " << z() << ", "
-                   << w() << ")";
-    }
-    return str_result.str();
-}
-
-// ***************************************************************************//
-//     Specializations for single-precision floating numbers (float32_t)      //
-// ***************************************************************************//
-using Vec4f = Vector4<float32_t>;
-
-template <>
-TM_INLINE auto Vec4f::dot(const Vec4f& other) const -> float32_t {
-#if defined(TINYMATH_SSE_ENABLED)
-    return sse::kernel_dot_v4f(elements(), other.elements());
+/// \brief Returns the dot-product of the given two vectors
+template <typename T, SFINAE_VEC4_GUARD<T> = nullptr>
+TM_INLINE auto dot(const Vector4<T>& lhs, const Vector4<T>& rhs) -> T {
+#if defined(TINYMATH_AVX_ENABLED)
+    // @todo(wilbert): call the appropriate AVX implementation
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert): call the appropriate SSE implementation
 #else
-    return scalar::kernel_dot_v4f(elements(), other.elements());
+    return scalar::kernel_dot_vec4<T>(lhs.elements(), rhs.elements());
 #endif
 }
 
-template <>
-TM_INLINE auto operator+(const Vec4f& lhs, const Vec4f& rhs) -> Vec4f {
-    Vec4f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    // SSE allows SIMD addition of 4-float packed vectors, so we use it here
-    sse::kernel_add_v4f(result.elements(), lhs.elements(), rhs.elements());
+/// \brief Returns the vector-sum of two 4d vector operands
+///
+/// \tparam T Type of scalar value used for the 4d-vector operands
+///
+/// This operator implements an element-wise sum of two Vector4 operands given
+/// as input arguments. The internal operator selects the appropriate "kernel"
+/// (just a function) to which to call, depending on whether or not the library
+/// was compiled using SIMD support (i.e. SSE and AVX function intrinsics will
+/// be used to handle the operation).
+///
+/// \param[in] lhs Left-hand-side operand of the vector-sum
+/// \param[in] rhs Right-hand-side operand of the vector-sum
+template <typename T, SFINAE_VEC4_GUARD<T> = nullptr>
+TM_INLINE auto operator+(const Vector4<T>& lhs, const Vector4<T>& rhs)
+    -> Vector4<T> {
+    Vector4<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    // @todo(wilbert): call the appropriate AVX implementation
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert): call the appropriate SSE implementation
 #else
-    // Use scalar version for all other cases (AVX registers require 8-floats)
-    scalar::kernel_add_v4f(result.elements(), lhs.elements(), rhs.elements());
+    scalar::kernel_add_vec4<T>(dst.elements(), lhs.elements(), rhs.elements());
 #endif
-    return result;
+    return dst;
 }
 
-template <>
-TM_INLINE auto operator-(const Vec4f& lhs, const Vec4f& rhs) -> Vec4f {
-    Vec4f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    // SSE allows SIMD substraction of 4-float packed vectors, so we use it here
-    sse::kernel_sub_v4f(result.elements(), lhs.elements(), rhs.elements());
+/// \brief Returns the vector-difference of two 4d vector operands
+///
+/// \tparam T Type of scalar value used for the 4d-vector operands
+///
+/// This operator implements an element-wise difference of two Vector4 operands
+/// given as input arguments. The internal operator selects the appropriate
+/// "kernel" (just a function) to which to call, depending on whether or not the
+/// library was compiled using SIMD support (i.e. SSE and AVX function
+/// intrinsics will be used to handle the operation).
+///
+/// \param[in] lhs Left-hand-side operand of the vector-sum
+/// \param[in] rhs Right-hand-side operand of the vector-sum
+template <typename T, SFINAE_VEC4_GUARD<T> = nullptr>
+TM_INLINE auto operator-(const Vector4<T>& lhs, const Vector4<T>& rhs)
+    -> Vector4<T> {
+    Vector4<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    // @todo(wilbert): call the appropriate AVX implementation
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert): call the appropriate SSE implementation
 #else
-    // Use scalar version for all other cases (AVX registers require 8-floats)
-    scalar::kernel_sub_v4f(result.elements(), lhs.elements(), rhs.elements());
+    scalar::kernel_sub_vec4<T>(dst.elements(), lhs.elements(), rhs.elements());
 #endif
-    return result;
+    return dst;
 }
 
-template <>
-TM_INLINE auto operator*(float32_t scale, const Vec4f& vec) -> Vec4f {
-    Vec4f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    sse::kernel_scale_v4f(result.elements(), scale, vec.elements());
+/// \brief Returns the scalar-vector product of a scalar and 4d vector operands
+///
+/// \tparam T Type of scalar used by both scalar and vector operands
+///
+/// This operator implements the scalar-vector product of two operands (a scalar
+/// and a vector in that order) given as input arguments. The internal operator
+/// selects the appropriate "kernel" (just a function) to which to call,
+/// depending on whether or not the library was compiled using SIMD support
+/// (i.e. SSE and AVX function intrinsics will be used to handle the operation).
+///
+/// \param[in] scale Scalar value by which to scale the second operand
+/// \param[in] vec Vector in 4d-space which we want to scale
+template <typename T, SFINAE_VEC4_GUARD<T> = nullptr>
+TM_INLINE auto operator*(T scale, const Vector4<T>& vec) -> Vector4<T> {
+    Vector4<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    // @todo(wilbert): call the appropriate AVX implementation
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert): call the appropriate SSE implementation
 #else
-    scalar::kernel_scale_v4f(result.elements(), scale, vec.elements());
+    scalar::kernel_scale_vec4<T>(dst.elements(), scale, vec.elements());
 #endif
-    return result;
+    return dst;
 }
 
-template <>
-TM_INLINE auto operator*(const Vec4f& vec, float32_t scale) -> Vec4f {
-    Vec4f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    sse::kernel_scale_v4f(result.elements(), scale, vec.elements());
+/// \brief Returns the vector-scalar product of a 4d vector and scalar operands
+///
+/// \tparam T Type of scalar used by both vector and scalar operands
+///
+/// This operator implements the vector-scalar product of two operands (a vector
+/// and a scalar in that order) given as input arguments. The internal operator
+/// selects the appropriate "kernel" (just a function) to which to call,
+/// depending on whether or not the library was compiled using SIMD support
+/// (i.e. SSE and AVX function intrinsics will be used to handle the operation).
+///
+/// \param[in] vec Vector in 4d-space which we want to scale
+/// \param[in] scale Scalar value by which to scale the first operand
+template <typename T, SFINAE_VEC4_GUARD<T> = nullptr>
+TM_INLINE auto operator*(const Vector4<T>& vec, T scale) -> Vector4<T> {
+    Vector4<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    // @todo(wilbert): call the appropriate AVX implementation
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert): call the appropriate SSE implementation
 #else
-    scalar::kernel_scale_v4f(result.elements(), scale, vec.elements());
+    scalar::kernel_scale_vec4<T>(dst.elements(), scale, vec.elements());
 #endif
-    return result;
+    return dst;
 }
 
-template <>
-TM_INLINE auto operator*(const Vec4f& lhs, const Vec4f& rhs) -> Vec4f {
-    Vec4f result;
-#if defined(TINYMATH_SSE_ENABLED)
-    sse::kernel_hadamard_v4f(result.elements(), lhs.elements(), rhs.elements());
+/// \brief Returns the element-wise product of two 4d vector operands
+///
+/// \tparam T Type of scalar value used by the 4d-vector operands
+///
+/// This operator implements an element-wise product (Hadamard-Schur product) of
+/// two Vector4 operands given as input arguments. The internal operator selects
+/// the appropriate "kernel" (just a function) to which to call, depending on
+/// whether or not the library was compiled using SIMD support (i.e. SSE and AVX
+/// function intrinsics will be used to handle the operation).
+///
+/// \param[in] lhs Left-hand-side operand of the element-wise product
+/// \param[in] rhs Right-hand-side operand of the element-wise product
+template <typename T, SFINAE_VEC4_GUARD<T> = nullptr>
+TM_INLINE auto operator*(const Vector4<T>& lhs, const Vector4<T>& rhs)
+    -> Vector4<T> {
+    Vector4<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    // @todo(wilbert): call the appropriate AVX implementation
+#elif defined(TINYMATH_SSE_ENABLED)
+    // @todo(wilbert): call the appropriate SSE implementation
 #else
-    scalar::kernel_hadamard_v4f(result.elements(), lhs.elements(),
-                                rhs.elements());
+    scalar::kernel_hadamard_vec4<T>(dst.elements(), lhs.elements(),
+                                    rhs.elements());
 #endif
-    return result;
+    return dst;
 };
 
-template <>
-TM_INLINE auto operator==(const Vec4f& lhs, const Vec4f& rhs) -> bool {
-    return scalar::kernel_compare_eq_v4f(lhs.elements(), rhs.elements());
+/// \brief Checks if two given vectors are "equal" (within epsilon margin)
+///
+/// \tparam Scalar_T Type of scalar value used by the 4d-vector operands
+///
+/// This operator implements an "np.allclose"-like operation (numpy's allclose
+/// function), checking if the corresponding (x,y,z) entries of both operands
+/// are within a certain margin "epsilon" (pre-defined constant). There was an
+/// "equal"-like SIMD instruction that implements floating point comparisons,
+/// however, we're not using it as single-precision floating point operations
+/// and transformation functions within the library might result in compounding
+/// errors that the user might want to test a small margin of error tuned
+/// appropriately (specially for single-precision floating point types)
+///
+/// \param[in] lhs Left-hand-side operand of the comparison
+/// \param[in] rhs Right-hand-side operand of the comparison
+/// \returns true if the given vectors are within a pre-defined epsilon margin
+template <typename T, SFINAE_VEC4_GUARD<T> = nullptr>
+TM_INLINE auto operator==(const Vector4<T>& lhs, const Vector4<T>& rhs)
+    -> bool {
+    return scalar::kernel_compare_eq_vec4<T>(lhs.elements(), rhs.elements());
 }
 
-template <>
-TM_INLINE auto operator!=(const Vec4f& lhs, const Vec4f& rhs) -> bool {
-    return !scalar::kernel_compare_eq_v4f(lhs.elements(), rhs.elements());
-}
-
-// ***************************************************************************//
-//     Specializations for double-precision floating numbers (float64_t)      //
-// ***************************************************************************//
-using Vec4d = Vector4<float64_t>;
-
-template <>
-TM_INLINE auto Vec4d::dot(const Vec4d& other) const -> float64_t {
-#if defined(TINYMATH_AVX_ENABLED)
-    return avx::kernel_dot_v4d(elements(), other.elements());
-#else
-    return scalar::kernel_dot_v4d(elements(), other.elements());
-#endif
-}
-
-template <>
-TM_INLINE auto operator+(const Vec4d& lhs, const Vec4d& rhs) -> Vec4d {
-    Vec4d result;
-#if defined(TINYMATH_AVX_ENABLED)
-    // AVX allows SIMD addition of 4-double packed vectors, so we use it
-    avx::kernel_add_v4d(result.elements(), lhs.elements(), rhs.elements());
-#else
-    // Use scalar version for all other cases, SSE register width is not enough
-    scalar::kernel_add_v4d(result.elements(), lhs.elements(), rhs.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator-(const Vec4d& lhs, const Vec4d& rhs) -> Vec4d {
-    Vec4d result;
-#if defined(TINYMATH_AVX_ENABLED)
-    // AVX allows SIMD substraction of 4-double packed vectors, so we use it
-    avx::kernel_sub_v4d(result.elements(), lhs.elements(), rhs.elements());
-#else
-    // Use scalar version for all other cases, SSE register width is not enough
-    scalar::kernel_sub_v4d(result.elements(), lhs.elements(), rhs.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator*(float64_t scale, const Vec4d& vec) -> Vec4d {
-    Vec4d result;
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_scale_v4d(result.elements(), scale, vec.elements());
-#else
-    scalar::kernel_scale_v4d(result.elements(), scale, vec.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator*(const Vec4d& vec, float64_t scale) -> Vec4d {
-    Vec4d result;
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_scale_v4d(result.elements(), scale, vec.elements());
-#else
-    scalar::kernel_scale_v4d(result.elements(), scale, vec.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator*(const Vec4d& lhs, const Vec4d& rhs) -> Vec4d {
-    Vec4d result;
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_hadamard_v4d(result.elements(), lhs.elements(), rhs.elements());
-#else
-    scalar::kernel_hadamard_v4d(result.elements(), lhs.elements(),
-                                rhs.elements());
-#endif
-    return result;
-}
-
-template <>
-TM_INLINE auto operator==(const Vec4d& lhs, const Vec4d& rhs) -> bool {
-    return scalar::kernel_compare_eq_v4d(lhs.elements(), rhs.elements());
-}
-
-template <>
-TM_INLINE auto operator!=(const Vec4d& lhs, const Vec4d& rhs) -> bool {
-    return !scalar::kernel_compare_eq_v4d(lhs.elements(), rhs.elements());
+/// \brief Checks if two given vectors are not "equal" (within epsilon margin)
+///
+/// \tparam Scalar_T Type of scalar value used by the 4d-vector operands
+///
+/// \param[in] lhs Left-hand-side operand of the comparison
+/// \param[in] rhs Right-hand-side operand of the comparison
+/// \returns true if the given vectors are not within a pre-defined margin
+template <typename T, SFINAE_VEC4_GUARD<T> = nullptr>
+TM_INLINE auto operator!=(const Vector4<T>& lhs, const Vector4<T>& rhs)
+    -> bool {
+    return !scalar::kernel_compare_eq_vec4<T>(lhs.elements(), rhs.elements());
 }
 
 }  // namespace math

--- a/tests/cpp/test_vec4_operations.cpp
+++ b/tests/cpp/test_vec4_operations.cpp
@@ -162,7 +162,7 @@ TEMPLATE_TEST_CASE("Vector4 class (vec4_t) core Operations", "[vec4_t][ops]",
 
         auto dot = val_x_a * val_x_b + val_y_a * val_y_b + val_z_a * val_z_b +
                    val_w_a * val_w_b;
-        auto v_dot = v_a.dot(v_b);
+        auto v_dot = tiny::math::dot(v_a, v_b);
 
         REQUIRE(std::abs(v_dot - dot) < EPSILON);
     }


### PR DESCRIPTION
# Description

Currently we have quite a lot of duplicated code for f32 and f64 on vec4 types, which can be simplified by using [`SFINAE`][0], as it was for mat4 types.

## Checklist|Tasks

- [x] `SFINAE` vec4 API (refactor operators usage)
- [x] `SFINAE` for Scalar-kernels
- [ ] `SFINAE` for SSE-kernels
- [ ] `SFINAE` for AVX-kernels

[0]: <https://en.cppreference.com/w/cpp/language/sfinae> (sfinae-cpp-reference)
