### PR TITLE
Updates workflows to check for SIMD support

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -71,7 +71,7 @@ with section("lint"):
 
     # regular expression pattern describing valid names for variables with local
     # scope
-    local_var_pattern = "[a-z][a-z0-9_]+"
+    local_var_pattern = "[0-9a-zA-Z_]+"
 
     # regular expression pattern describing valid names for privatedirectory
     # variables

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,12 +28,10 @@ jobs:
 
     - name: Configure C/C++ compiler • [${{matrix.compiler}}]
       run: |
-        if [ "${{matrix.compiler}}" == "gcc" ]
-        then
+        if [ "${{matrix.compiler}}" == "gcc" ]; then
           export CC=gcc
           export CXX=g++;
-        elif [ "${{matrix.compiler}} == "clang" ]
-        then
+        elif [ "${{matrix.compiler}} == "clang" ]; then
           export CC=clang
           export CXX=clang++
         else
@@ -42,18 +40,15 @@ jobs:
 
     - name: Configure Vectorization • [${{matrix.vectorization}}]
       run: |
-        if [ "${{matrix.vectorization}}" == "none" ]
-        then
+        if [ "${{matrix.vectorization}}" == "none" ]; then
           export SIMD_USE_SSE=OFF
           export SIMD_USE_AVX=OFF
-        elif [ "${{matrix.vectorization}}" == "simd-sse" ]
-        then
+        elif [ "${{matrix.vectorization}}" == "simd-sse" ]; then
           export SIMD_USE_SSE=ON
         elif [ "${{matrix.vectorization}}" == "simd-avx" ]
         then
           export SIMD_USE_AVX=ON
-        elif [ "${{matrix.vectorization}}" == "simd-full" ]
-        then
+        elif [ "${{matrix.vectorization}}" == "simd-full" ]; then
           export SIMD_USE_SSE=ON
           export SIMD_USE_AVX=ON
         else

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-18.04, ubuntu-latest]
         compiler: [gcc, clang]
         build-type: [Release, Debug]
-        vectorization: [none, simd-sse, simd-avx]
+        vectorization: [none, simd-sse, simd-avx, simd-full]
 
     name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • ${{matrix.compiler}}  • vectorization:[${{matrix.vectorization}}]"
     runs-on: ${{matrix.os}}
@@ -26,37 +26,39 @@ jobs:
     - name: Update CMake
       uses: jwlawson/actions-setup-cmake@v1.10
 
-    - if: ${{matrix.compiler}} == gcc
-      name: Configure C/C++ compiler [GCC]
-      env:
-        CC: gcc
-        CXX: g++
+    - name: Configure C/C++ compiler • [${{matrix.compiler}}]
       run: |
-        gcc --version
-        g++ --version
+        if [ "${{matrix.compiler}}" == "gcc" ]
+        then
+          export CC=gcc
+          export CXX=g++;
+        elif [ "${{matrix.compiler}} == "clang" ]
+        then
+          export CC=clang
+          export CXX=clang++
+        else
+          echo "Compiler ${{matrix.compiler}} not supported yet"
+        fi
 
-    - if: ${{matrix.compiler}} == clang
-      name: Configure C/C++ compiler [Clang]
-      env:
-        CC: clang
-        CXX: clang++
+    - name: Configure Vectorization • [${{matrix.vectorization}}]
       run: |
-        clang --version
-        clang++ --version
-
-    - if: ${{matrix.vectorization}} == none
-      name: Do not force vectorization (use cmake-options instead)
-      run: |
-        unset SIMD_USE_SSE
-        unset SIMD_USE_AVX
-
-    - if: ${{matrix.vectorization}} == simd-sse
-      name: Try [simd-sse] if available
-      run: export SIMD_USE_SSE=ON
-
-    - if: ${{matrix.vectorization}} == simd-avx
-      name: Try [simd-avx] if available
-      run: export SIMD_USE_AVX=ON
+        if [ "${{matrix.vectorization}}" == "none" ]
+        then
+          export SIMD_USE_SSE=OFF
+          export SIMD_USE_AVX=OFF
+        elif [ "${{matrix.vectorization}}" == "simd-sse" ]
+        then
+          export SIMD_USE_SSE=ON
+        elif [ "${{matrix.vectorization}}" == "simd-avx" ]
+        then
+          export SIMD_USE_AVX=ON
+        elif [ "${{matrix.vectorization}}" == "simd-full" ]
+        then
+          export SIMD_USE_SSE=ON
+          export SIMD_USE_AVX=ON
+        else
+          echo "We do not yet support vectorization type [${{matrix.vectorization}}]"
+        fi
 
     - name: Configure CMake
       run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,17 +28,17 @@ jobs:
 
     - if: ${{ matrix.compiler == 'gcc' }}
       name: Configure GNU/GCC as C/C++ compiler
-      env:
-        CC: gcc
-        CXX: g++
-      run: echo "Choosing GNU/GCC as compiler"
+      run: |
+        echo "Choosing GNU/GCC as compiler"
+        echo "CC=gcc" >> $GITHUB_ENV
+        echo "CXX=g++" >> $GITHUB_ENV
 
     - if: ${{ matrix.compiler == 'clang' }}
       name: Configure LLVM/Clang as C/C++ compiler
-      env:
-        CC: clang
-        CXX: clang++
-      run: echo "Choosing LLVM/Clang as compiler"
+      run: |
+        echo "Choosing LLVM/Clang as compiler"
+        echo "CC=clang" >> $GITHUB_ENV
+        echo "CXX=clang++" >> $GITHUB_ENV
 
     - name: Configure Vectorization • [${{matrix.vectorization}}]
       run: |
@@ -61,7 +61,9 @@ jobs:
         fi
 
     - name: Check environment settings
-      run: printenv
+      run: |
+        printenv
+        echo "github-env: ${GITHUB_ENV}"
 
     - name: Configure CMake
       run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -26,19 +26,19 @@ jobs:
     - name: Update CMake
       uses: jwlawson/actions-setup-cmake@v1.10
 
-    - name: Configure C/C++ compiler • [${{matrix.compiler}}]
-      run: |
-        if [ "${{matrix.compiler}}" = "gcc" ]; then
-          export CC=gcc
-          export CXX=g++
-          echo "Choosing GNU/GCC as compiler"
-        elif [ "${{matrix.compiler}}" = "clang" ]; then
-          export CC=clang
-          export CXX=clang++
-          echo "Choosing LLVM/Clang as compiler"
-        else
-          echo "Compiler ${{matrix.compiler}} not supported yet"
-        fi
+    - if: ${{ matrix.compiler == 'gcc' }}
+      name: Configure GNU/GCC as C/C++ compiler
+      env:
+        CC=gcc
+        CXX=g++
+      run: echo "Choosing GNU/GCC as compiler"
+
+    - if: ${{ matrix.compiler == 'clang' }}
+      name: Configure LLVM/Clang as C/C++ compiler
+      env:
+        CC=clang
+        CXX=clang++
+      run: echo "Choosing LLVM/Clang as compiler"
 
     - name: Configure Vectorization • [${{matrix.vectorization}}]
       run: |

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -28,29 +28,34 @@ jobs:
 
     - name: Configure C/C++ compiler • [${{matrix.compiler}}]
       run: |
-        if [ "${{matrix.compiler}}" == "gcc" ]; then
+        if [ "${{matrix.compiler}}" = "gcc" ]; then
           export CC=gcc
-          export CXX=g++;
-        elif [ "${{matrix.compiler}}" == "clang" ]; then
+          export CXX=g++
+          echo "Choosing GNU/GCC as compiler"
+        elif [ "${{matrix.compiler}}" = "clang" ]; then
           export CC=clang
           export CXX=clang++
+          echo "Choosing LLVM/Clang as compiler"
         else
           echo "Compiler ${{matrix.compiler}} not supported yet"
         fi
 
     - name: Configure Vectorization • [${{matrix.vectorization}}]
       run: |
-        if [ "${{matrix.vectorization}}" == "none" ]; then
+        if [ "${{matrix.vectorization}}" = "none" ]; then
           export SIMD_USE_SSE=OFF
           export SIMD_USE_AVX=OFF
-        elif [ "${{matrix.vectorization}}" == "simd-sse" ]; then
+          echo "No vectorization (just use scalar kernels)"
+        elif [ "${{matrix.vectorization}}" = "simd-sse" ]; then
           export SIMD_USE_SSE=ON
-        elif [ "${{matrix.vectorization}}" == "simd-avx" ]
-        then
+          echo "Try to use SSE kernels if the CPU has support for this ISA"
+        elif [ "${{matrix.vectorization}}" = "simd-avx" ]; then
           export SIMD_USE_AVX=ON
-        elif [ "${{matrix.vectorization}}" == "simd-full" ]; then
+          echo "Try to use AVX kernels if the CPU has support for this ISA"
+        elif [ "${{matrix.vectorization}}" = "simd-full" ]; then
           export SIMD_USE_SSE=ON
           export SIMD_USE_AVX=ON
+          echo "Try to use both SSE and AVX kernels if the CPU supports both"
         else
           echo "We do not yet support vectorization type [${{matrix.vectorization}}]"
         fi

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -60,6 +60,9 @@ jobs:
           echo "We do not yet support vectorization type [${{matrix.vectorization}}]"
         fi
 
+    - name: Check environment settings
+      run: printenv
+
     - name: Configure CMake
       run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
 

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -8,14 +8,16 @@ on:
       - dev
 
 jobs:
-  build-gcc:
+  build:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-latest]
+        compiler: [gcc, clang]
         build-type: [Release, Debug]
+        vectorization: [none, simd-sse, simd-avx]
 
-    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • GCC"
+    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • ${{matrix.compiler}}  • vectorization:[${{matrix.vectorization}}]"
     runs-on: ${{matrix.os}}
 
     steps:
@@ -24,38 +26,39 @@ jobs:
     - name: Update CMake
       uses: jwlawson/actions-setup-cmake@v1.10
 
-    - name: Configure CMake
+    - if: ${{matrix.compiler}} == gcc
+      name: Configure C/C++ compiler [GCC]
       env:
         CC: gcc
         CXX: g++
-      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+      run: |
+        gcc --version
+        g++ --version
 
-    - name: Build C++ Project
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}
-
-    - name: Running C++ Tests
-      run: ctest --test-dir ${{github.workspace}}/build/tests/cpp
-
-  build-clang:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-18.04, ubuntu-latest]
-        build-type: [Release, Debug]
-
-    name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • Clang"
-    runs-on: ${{matrix.os}}
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Update CMake
-      uses: jwlawson/actions-setup-cmake@v1.10
-
-    - name: Configure CMake
+    - if: ${{matrix.compiler}} == clang
+      name: Configure C/C++ compiler [Clang]
       env:
         CC: clang
         CXX: clang++
+      run: |
+        clang --version
+        clang++ --version
+
+    - if: ${{matrix.vectorization}} == none
+      name: Do not force vectorization (use cmake-options instead)
+      run: |
+        unset SIMD_USE_SSE
+        unset SIMD_USE_AVX
+
+    - if: ${{matrix.vectorization}} == simd-sse
+      name: Try [simd-sse] if available
+      run: export SIMD_USE_SSE=ON
+
+    - if: ${{matrix.vectorization}} == simd-avx
+      name: Try [simd-avx] if available
+      run: export SIMD_USE_AVX=ON
+
+    - name: Configure CMake
       run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
 
     - name: Build C++ Project

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -43,27 +43,22 @@ jobs:
     - name: Configure Vectorization • [${{matrix.vectorization}}]
       run: |
         if [ "${{matrix.vectorization}}" = "none" ]; then
-          export SIMD_USE_SSE=OFF
-          export SIMD_USE_AVX=OFF
+          echo "SIMD_USE_SSE=OFF" >> $GITHUB_ENV
+          echo "SIMD_USE_AVX=OFF" >> $GITHUB_ENV
           echo "No vectorization (just use scalar kernels)"
         elif [ "${{matrix.vectorization}}" = "simd-sse" ]; then
-          export SIMD_USE_SSE=ON
+          echo "SIMD_USE_SSE=ON" >> $GITHUB_ENV
           echo "Try to use SSE kernels if the CPU has support for this ISA"
         elif [ "${{matrix.vectorization}}" = "simd-avx" ]; then
-          export SIMD_USE_AVX=ON
+          echo "SIMD_USE_AVX=ON" >> $GITHUB_ENV
           echo "Try to use AVX kernels if the CPU has support for this ISA"
         elif [ "${{matrix.vectorization}}" = "simd-full" ]; then
-          export SIMD_USE_SSE=ON
-          export SIMD_USE_AVX=ON
+          echo "SIMD_USE_SSE=ON" >> $GITHUB_ENV
+          echo "SIMD_USE_AVX=ON" >> $GITHUB_ENV
           echo "Try to use both SSE and AVX kernels if the CPU supports both"
         else
           echo "We do not yet support vectorization type [${{matrix.vectorization}}]"
         fi
-
-    - name: Check environment settings
-      run: |
-        printenv
-        echo "github-env: ${GITHUB_ENV}"
 
     - name: Configure CMake
       run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -29,15 +29,15 @@ jobs:
     - if: ${{ matrix.compiler == 'gcc' }}
       name: Configure GNU/GCC as C/C++ compiler
       env:
-        CC=gcc
-        CXX=g++
+        CC: gcc
+        CXX: g++
       run: echo "Choosing GNU/GCC as compiler"
 
     - if: ${{ matrix.compiler == 'clang' }}
       name: Configure LLVM/Clang as C/C++ compiler
       env:
-        CC=clang
-        CXX=clang++
+        CC: clang
+        CXX: clang++
       run: echo "Choosing LLVM/Clang as compiler"
 
     - name: Configure Vectorization • [${{matrix.vectorization}}]

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -31,7 +31,7 @@ jobs:
         if [ "${{matrix.compiler}}" == "gcc" ]; then
           export CC=gcc
           export CXX=g++;
-        elif [ "${{matrix.compiler}} == "clang" ]; then
+        elif [ "${{matrix.compiler}}" == "clang" ]; then
           export CC=clang
           export CXX=clang++
         else

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Configure CMake
       env:
-        CMAKE_GENERATOR: "Visual Studio 16 2019"
+        CMAKE_GENERATOR: "Visual Studio 17 2022"
       run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
 
     - name: Build C++ Project

--- a/include/tinymath/impl/vec3_t_avx_impl.hpp
+++ b/include/tinymath/impl/vec3_t_avx_impl.hpp
@@ -158,9 +158,8 @@ template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
     COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x71;
     auto xmm_v = _mm_load_ps(vec.data());
-    return _mm_cvtss_f32(_mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK));
+    return _mm_cvtss_f32(_mm_dp_ps(xmm_v, xmm_v, 0x71));
 }
 
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
@@ -184,9 +183,8 @@ template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
     COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x71;
     auto xmm_v = _mm_load_ps(vec.data());
-    return _mm_cvtss_f32(_mm_sqrt_ss(_mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK)));
+    return _mm_cvtss_f32(_mm_sqrt_ss(_mm_dp_ps(xmm_v, xmm_v, 0x71)));
 }
 
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
@@ -210,9 +208,8 @@ template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
     COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x7f;
     auto xmm_v = _mm_load_ps(vec.data());
-    auto xmm_sums = _mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK);
+    auto xmm_sums = _mm_dp_ps(xmm_v, xmm_v, 0x7f);
     auto xmm_r_sqrt_sums = _mm_sqrt_ps(xmm_sums);
     auto xmm_v_norm = _mm_div_ps(xmm_v, xmm_r_sqrt_sums);
     _mm_store_ps(vec.data(), xmm_v_norm);
@@ -238,10 +235,9 @@ template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> T {
     COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
-    constexpr int32_t COND_PROD_MASK = 0x71;
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
-    auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, COND_PROD_MASK);
+    auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0x71);
     return _mm_cvtss_f32(xmm_cond_prod);
 }
 
@@ -264,8 +260,6 @@ TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                  const Vec3Buffer<T>& rhs) -> void {
     COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     // Implementation adapted from @ian_mallett (https://bit.ly/3lu6pVe)
-    constexpr auto MASK_A = tiny::math::ShuffleMask<3, 0, 2, 1>::value;
-    constexpr auto MASK_B = tiny::math::ShuffleMask<3, 1, 0, 2>::value;
     // Recall that the dot product of two 3d-vectors a and b given by:
     // a = {a[0], a[1], a[2], a[3]=0}, b = {b[0], b[1], b[2], b[3]=0}
     // has as resulting expression:
@@ -276,13 +270,21 @@ TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
     auto vec_a = _mm_load_ps(lhs.data());  // a = {a[0], a[1], a[2], a[3]=0}
     auto vec_b = _mm_load_ps(rhs.data());  // b = {b[0], b[1], b[2], b[3]=0}
     // tmp_0 = {a[1], a[2], a[0], 0}
-    auto tmp_0 = _mm_shuffle_ps(vec_a, vec_a, MASK_A);
+    auto tmp_0 = _mm_shuffle_ps(
+        vec_a, vec_a,
+        static_cast<int>(tiny::math::ShuffleMask<3, 0, 2, 1>::value));
     // tmp_1 = {b[2], b[0], b[1], 0}
-    auto tmp_1 = _mm_shuffle_ps(vec_b, vec_b, MASK_B);
+    auto tmp_1 = _mm_shuffle_ps(
+        vec_b, vec_b,
+        static_cast<int>(tiny::math::ShuffleMask<3, 1, 0, 2>::value));
     // tmp_2 = {a[2], a[0], a[1], 0}
-    auto tmp_2 = _mm_shuffle_ps(vec_a, vec_a, MASK_B);
+    auto tmp_2 = _mm_shuffle_ps(
+        vec_a, vec_a,
+        static_cast<int>(tiny::math::ShuffleMask<3, 1, 0, 2>::value));
     // tmp_3 = {b[1], b[2], b[0], 0}
-    auto tmp_3 = _mm_shuffle_ps(vec_b, vec_b, MASK_A);
+    auto tmp_3 = _mm_shuffle_ps(
+        vec_b, vec_b,
+        static_cast<int>(tiny::math::ShuffleMask<3, 0, 2, 1>::value));
     _mm_store_ps(dst.data(), _mm_sub_ps(_mm_mul_ps(tmp_0, tmp_1),
                                         _mm_mul_ps(tmp_2, tmp_3)));
 }

--- a/include/tinymath/impl/vec3_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec3_t_sse_impl.hpp
@@ -179,20 +179,18 @@ template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
     COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x71;
     auto xmm_v = _mm_load_ps(vec.data());
-    return _mm_cvtss_f32(_mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK));
+    return _mm_cvtss_f32(_mm_dp_ps(xmm_v, xmm_v, 0x71));
 }
 
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
     COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x31;
     auto xmm_v_lo = _mm_load_pd(vec.data());
     auto xmm_v_hi = _mm_load_pd(vec.data() + 2);
-    auto xmm_square_sum_lo = _mm_dp_pd(xmm_v_lo, xmm_v_lo, COND_PROD_MASK);
-    auto xmm_square_sum_hi = _mm_dp_pd(xmm_v_hi, xmm_v_hi, COND_PROD_MASK);
+    auto xmm_square_sum_lo = _mm_dp_pd(xmm_v_lo, xmm_v_lo, 0x31);
+    auto xmm_square_sum_hi = _mm_dp_pd(xmm_v_hi, xmm_v_hi, 0x31);
     auto xmm_square_sum = _mm_add_pd(xmm_square_sum_lo, xmm_square_sum_hi);
     return _mm_cvtsd_f64(xmm_square_sum);
 }
@@ -201,20 +199,18 @@ template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
     COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x71;
     auto xmm_v = _mm_load_ps(vec.data());
-    return _mm_cvtss_f32(_mm_sqrt_ss(_mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK)));
+    return _mm_cvtss_f32(_mm_sqrt_ss(_mm_dp_ps(xmm_v, xmm_v, 0x71)));
 }
 
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
     COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x31;
     auto xmm_v_01 = _mm_load_pd(vec.data());
     auto xmm_v_23 = _mm_load_pd(vec.data() + 2);
-    auto xmm_square_sum_01 = _mm_dp_pd(xmm_v_01, xmm_v_01, COND_PROD_MASK);
-    auto xmm_square_sum_23 = _mm_dp_pd(xmm_v_23, xmm_v_23, COND_PROD_MASK);
+    auto xmm_square_sum_01 = _mm_dp_pd(xmm_v_01, xmm_v_01, 0x31);
+    auto xmm_square_sum_23 = _mm_dp_pd(xmm_v_23, xmm_v_23, 0x31);
     auto xmm_square_sum = _mm_add_pd(xmm_square_sum_01, xmm_square_sum_23);
     return _mm_cvtsd_f64(_mm_sqrt_sd(xmm_square_sum, xmm_square_sum));
 }
@@ -223,9 +219,8 @@ template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
     COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x7f;
     auto xmm_v = _mm_load_ps(vec.data());
-    auto xmm_sums = _mm_dp_ps(xmm_v, xmm_v, COND_PROD_MASK);
+    auto xmm_sums = _mm_dp_ps(xmm_v, xmm_v, 0x7f);
     auto xmm_r_sqrt_sums = _mm_sqrt_ps(xmm_sums);
     auto xmm_v_norm = _mm_div_ps(xmm_v, xmm_r_sqrt_sums);
     _mm_store_ps(vec.data(), xmm_v_norm);
@@ -235,11 +230,10 @@ template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
     COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
-    constexpr int32_t COND_PROD_MASK = 0x33;
     auto xmm_v_01 = _mm_load_pd(vec.data());
     auto xmm_v_23 = _mm_load_pd(vec.data() + 2);
-    auto xmm_sums_01 = _mm_dp_pd(xmm_v_01, xmm_v_01, COND_PROD_MASK);
-    auto xmm_sums_23 = _mm_dp_pd(xmm_v_23, xmm_v_23, COND_PROD_MASK);
+    auto xmm_sums_01 = _mm_dp_pd(xmm_v_01, xmm_v_01, 0x33);
+    auto xmm_sums_23 = _mm_dp_pd(xmm_v_23, xmm_v_23, 0x33);
     auto xmm_r_sqrt_sums = _mm_sqrt_pd(_mm_add_pd(xmm_sums_01, xmm_sums_23));
     auto xmm_v_norm_01 = _mm_div_pd(xmm_v_01, xmm_r_sqrt_sums);
     auto xmm_v_norm_23 = _mm_div_pd(xmm_v_23, xmm_r_sqrt_sums);
@@ -251,10 +245,9 @@ template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> T {
     COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
-    constexpr int32_t COND_PROD_MASK = 0x71;
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
-    auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, COND_PROD_MASK);
+    auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0x71);
     return _mm_cvtss_f32(xmm_cond_prod);
 }
 
@@ -262,13 +255,12 @@ template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> T {
     COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
-    constexpr int32_t COND_PROD_MASK = 0x31;
     auto xmm_lhs_01 = _mm_load_pd(lhs.data());
     auto xmm_lhs_23 = _mm_load_pd(lhs.data() + 2);
     auto xmm_rhs_01 = _mm_load_pd(rhs.data());
     auto xmm_rhs_23 = _mm_load_pd(rhs.data() + 2);
-    auto xmm_dot_01 = _mm_dp_pd(xmm_lhs_01, xmm_rhs_01, COND_PROD_MASK);
-    auto xmm_dot_23 = _mm_dp_pd(xmm_lhs_23, xmm_rhs_23, COND_PROD_MASK);
+    auto xmm_dot_01 = _mm_dp_pd(xmm_lhs_01, xmm_rhs_01, 0x31);
+    auto xmm_dot_23 = _mm_dp_pd(xmm_lhs_23, xmm_rhs_23, 0x31);
     return _mm_cvtsd_f64(_mm_add_pd(xmm_dot_01, xmm_dot_23));
 }
 
@@ -277,8 +269,6 @@ TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                  const Vec3Buffer<T>& rhs) -> void {
     COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     // Implementation adapted from @ian_mallett (https://bit.ly/3lu6pVe)
-    constexpr auto MASK_A = tiny::math::ShuffleMask<3, 0, 2, 1>::value;
-    constexpr auto MASK_B = tiny::math::ShuffleMask<3, 1, 0, 2>::value;
     // Recall that the dot product of two 3d-vectors a and b given by:
     // a = {a[0], a[1], a[2], a[3]=0}, b = {b[0], b[1], b[2], b[3]=0}
     // has as resulting expression:
@@ -289,13 +279,21 @@ TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
     auto vec_a = _mm_load_ps(lhs.data());  // a = {a[0], a[1], a[2], a[3]=0}
     auto vec_b = _mm_load_ps(rhs.data());  // b = {b[0], b[1], b[2], b[3]=0}
     // tmp_0 = {a[1], a[2], a[0], 0}
-    auto tmp_0 = _mm_shuffle_ps(vec_a, vec_a, MASK_A);
+    auto tmp_0 = _mm_shuffle_ps(
+        vec_a, vec_a,
+        static_cast<int>(tiny::math::ShuffleMask<3, 0, 2, 1>::value));
     // tmp_1 = {b[2], b[0], b[1], 0}
-    auto tmp_1 = _mm_shuffle_ps(vec_b, vec_b, MASK_B);
+    auto tmp_1 = _mm_shuffle_ps(
+        vec_b, vec_b,
+        static_cast<int>(tiny::math::ShuffleMask<3, 1, 0, 2>::value));
     // tmp_2 = {a[2], a[0], a[1], 0}
-    auto tmp_2 = _mm_shuffle_ps(vec_a, vec_a, MASK_B);
+    auto tmp_2 = _mm_shuffle_ps(
+        vec_a, vec_a,
+        static_cast<int>(tiny::math::ShuffleMask<3, 1, 0, 2>::value));
     // tmp_3 = {b[1], b[2], b[0], 0}
-    auto tmp_3 = _mm_shuffle_ps(vec_b, vec_b, MASK_A);
+    auto tmp_3 = _mm_shuffle_ps(
+        vec_b, vec_b,
+        static_cast<int>(tiny::math::ShuffleMask<3, 0, 2, 1>::value));
     _mm_store_ps(dst.data(), _mm_sub_ps(_mm_mul_ps(tmp_0, tmp_1),
                                         _mm_mul_ps(tmp_2, tmp_3)));
 }

--- a/include/tinymath/impl/vec4_t_avx_impl.hpp
+++ b/include/tinymath/impl/vec4_t_avx_impl.hpp
@@ -154,10 +154,9 @@ template <typename T, SFINAE_VEC4_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> T {
     COMPILE_TIME_CHECKS_VEC4_F32_AVX<T>();
-    constexpr int32_t COND_PROD_MASK = 0xf1;
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
-    auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, COND_PROD_MASK);
+    auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0xf1);
     return _mm_cvtss_f32(xmm_cond_prod);
 }
 

--- a/include/tinymath/impl/vec4_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec4_t_sse_impl.hpp
@@ -174,10 +174,9 @@ template <typename T, SFINAE_VEC4_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> T {
     COMPILE_TIME_CHECKS_VEC4_F32_SSE<T>();
-    constexpr int32_t COND_PROD_MASK = 0xf1;
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
-    auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, COND_PROD_MASK);
+    auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0xf1);
     return _mm_cvtss_f32(xmm_cond_prod);
 }
 
@@ -185,13 +184,12 @@ template <typename T, SFINAE_VEC4_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> T {
     COMPILE_TIME_CHECKS_VEC4_F64_SSE<T>();
-    constexpr int32_t COND_PROD_MASK = 0x31;
     auto xmm_lhs_lo = _mm_load_pd(lhs.data());
     auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);
     auto xmm_rhs_lo = _mm_load_pd(rhs.data());
     auto xmm_rhs_hi = _mm_load_pd(rhs.data() + 2);
-    auto xmm_dot_lo = _mm_dp_pd(xmm_lhs_lo, xmm_rhs_lo, COND_PROD_MASK);
-    auto xmm_dot_hi = _mm_dp_pd(xmm_lhs_hi, xmm_rhs_hi, COND_PROD_MASK);
+    auto xmm_dot_lo = _mm_dp_pd(xmm_lhs_lo, xmm_rhs_lo, 0x31);
+    auto xmm_dot_hi = _mm_dp_pd(xmm_lhs_hi, xmm_rhs_hi, 0x31);
     return _mm_cvtsd_f64(_mm_add_pd(xmm_dot_lo, xmm_dot_hi));
 }
 


### PR DESCRIPTION
# Description
This PR adds builds on top of 97f09544b4c7056a340b3a63e23729f998bc6ae7 by adding ci rules to the gh-actions workflow in order to compile and test using `SIMD` on `x86_64` as well (either `SSE` or `AVX`)

Fixes #9