### PR TITLE
Adds base API for vec2-types

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 # List of all examples to be built
 set(TINYMATH_EXAMPLES_LIST
+    ${CMAKE_CURRENT_SOURCE_DIR}/example_vec2_constructors.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec3_constructors.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec3_operations.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec4_constructors.cpp

--- a/examples/cpp/example_vec2_constructors.cpp
+++ b/examples/cpp/example_vec2_constructors.cpp
@@ -31,8 +31,8 @@ auto run_example_vec2() -> void {
     Vec2 vec_b(1.0);
     Vec2 vec_c(1.0, 2.0);
     Vec2 vec_e = {2.0, 4.0};
-    //// Vec2 vec_f;
-    //// vec_f << 1.0, 2.0, 3.0;
+    Vec2 vec_f;
+    vec_f << 1.0, 2.0;
 
     // Send the sample vectors to the standard output stream
     std::cout << "Vector2()" << '\n';
@@ -43,8 +43,8 @@ auto run_example_vec2() -> void {
     std::cout << vec_c << "\n";
     std::cout << "Vector2 vec = {x, y}" << '\n';
     std::cout << vec_e << "\n";
-    //// std::cout << "Vector2 vec; vec << x, y, z;" << '\n';
-    //// std::cout << vec_f << "\n";
+    std::cout << "Vector2 vec; vec << x, y;" << '\n';
+    std::cout << vec_f << "\n";
 
     std::cout << "**********************************************************\n";
 }

--- a/examples/cpp/example_vec2_constructors.cpp
+++ b/examples/cpp/example_vec2_constructors.cpp
@@ -1,0 +1,60 @@
+#include <iomanip>
+#include <iostream>
+#include <tinymath/tinymath.hpp>
+#include <type_traits>
+
+#define ERROR_1 "Wrong number of bytes in internal storage"
+#define ERROR_2 "Wrong alignment of internal storage"
+
+template <typename T>
+auto run_example_vec2() -> void {
+    using Vec2 = tiny::math::Vector2<T>;
+
+    // Checking size and alignment (we won't do SIMD aligned load|store)
+    constexpr int EXPECTED_SIZE = 2 * sizeof(T);
+    constexpr int EXPECTED_ALIGNMENT = 2 * sizeof(T);
+    static_assert(EXPECTED_SIZE == Vec2::num_bytes_size(), ERROR_1);
+    static_assert(EXPECTED_ALIGNMENT == Vec2::num_bytes_alignment(), ERROR_2);
+
+    // Just note which scalar type we're using
+    if (std::is_same<T, float>()) {
+        std::cout << "Checking out Vector2<float> types *****************\n";
+    } else if (std::is_same<T, double>()) {
+        std::cout << "Checking out Vector2<double> types ****************\n";
+    } else {
+        std::cout << "Uhmmm, neither float nor double used as scalar type D:\n";
+        return;
+    }
+
+    // Using some of the constructors available for 3d-vector types
+    Vec2 vec_a;
+    Vec2 vec_b(1.0);
+    Vec2 vec_c(1.0, 2.0);
+    Vec2 vec_e = {2.0, 4.0};
+    //// Vec2 vec_f;
+    //// vec_f << 1.0, 2.0, 3.0;
+
+    // Send the sample vectors to the standard output stream
+    std::cout << "Vector2()" << '\n';
+    std::cout << vec_a << "\n";
+    std::cout << "Vector2(x)" << '\n';
+    std::cout << vec_b << "\n";
+    std::cout << "Vector2(x, y)" << '\n';
+    std::cout << vec_c << "\n";
+    std::cout << "Vector2 vec = {x, y}" << '\n';
+    std::cout << vec_e << "\n";
+    //// std::cout << "Vector2 vec; vec << x, y, z;" << '\n';
+    //// std::cout << vec_f << "\n";
+
+    std::cout << "**********************************************************\n";
+}
+
+auto main() -> int {
+    constexpr int32_t PRINT_PRECISION = 7;
+    std::cout << std::setprecision(PRINT_PRECISION);
+
+    run_example_vec2<float>();
+    run_example_vec2<double>();
+
+    return 0;
+}

--- a/include/tinymath/common.hpp
+++ b/include/tinymath/common.hpp
@@ -90,7 +90,6 @@ struct CpuHasAVX : public std::integral_constant<bool,
 ///
 /// \brief Helper class used during comma-initialization of vec-types
 ///
-/// \tparam T Type of scalar used for the vector being constructed
 /// \tparam V Type of vector related to this comma initializer
 ///
 /// This is a helper class used for operations of the form `v << 1, 2, 3, ...;`,
@@ -101,7 +100,7 @@ struct CpuHasAVX : public std::integral_constant<bool,
 ///     Vector3d vec;
 ///     vec << 1.0, 2.0, 3.0;
 /// \endcode
-template <typename T, typename V>
+template <typename V>
 struct VecCommaInitializer {
     /// Number of scalar dimensions of the vector
     static constexpr uint32_t VECTOR_NDIM = V::VECTOR_NDIM;
@@ -110,8 +109,10 @@ struct VecCommaInitializer {
     /// Index of the last vector entry on its storage buffer|array
     static constexpr int32_t VECTOR_LAST_INDEX = VECTOR_NDIM - 1;
 
+    /// Type alias for the float|scalar type in use
+    using T = typename V::ElementType;
     /// Type alias for this comma-initializer
-    using Type = VecCommaInitializer<T, V>;
+    using Type = VecCommaInitializer<V>;
     /// Type alias for the vector type linked to this initializer
     using VectorType = V;
 
@@ -124,15 +125,15 @@ struct VecCommaInitializer {
 
     // Follow RAII and the 'Rule of 5' (use defaults though) -------------------
 
-    VecCommaInitializer(const VecCommaInitializer<T, V>& rhs) = default;
+    VecCommaInitializer(const VecCommaInitializer<V>& rhs) = default;
 
-    VecCommaInitializer(VecCommaInitializer<T, V>&& rhs) noexcept = default;
+    VecCommaInitializer(VecCommaInitializer<V>&& rhs) noexcept = default;
 
-    auto operator=(const VecCommaInitializer<T, V>& rhs)
-        -> VecCommaInitializer<T, V>& = default;
+    auto operator=(const VecCommaInitializer<V>& rhs)
+        -> VecCommaInitializer<V>& = default;
 
-    auto operator=(VecCommaInitializer<T, V>&& rhs) noexcept
-        -> VecCommaInitializer<T, V>& = default;
+    auto operator=(VecCommaInitializer<V>&& rhs) noexcept
+        -> VecCommaInitializer<V>& = default;
 
     /// Release any resources and terminate the initializer's operation
     ~VecCommaInitializer() { _finished(); }

--- a/include/tinymath/common.hpp
+++ b/include/tinymath/common.hpp
@@ -22,7 +22,7 @@
 #endif
 
 // clang-format on
-
+#include <cstdint>
 #include <type_traits>
 
 namespace tiny {
@@ -84,6 +84,30 @@ struct CpuHasAVX : public std::integral_constant<bool,
                 IsScalar<Tp>::value && HAS_AVX::value> {};
 
 // clang-format on
+
+/// \class VecCommaInitializer
+///
+/// \brief Helper class used during comma-initialization of vec-types
+///
+/// \tparam Scalar_T Type of scalar used for the vector being constructed
+///
+/// This is a helper class used for operations of the form `v << 1, 2, 3, ...;`,
+/// which require to concatenate a comma-initializer after using the `<<`
+/// operator. This is based on Eigen's comma-initializer implementation.
+///
+/// \code
+///     Vector3d vec;
+///     vec << 1.0, 2.0, 3.0;
+/// \endcode
+template <typename T, uint32_t N>
+struct VecCommaInitializer {
+    /// Number of scalar dimensions of the vector
+    static constexpr uint32_t VECTOR_NDIM = N;
+    /// Index of the first vector entry on its storage buffer|array
+    static constexpr int32_t VECTOR_FIRST_INDEX = 0;
+    /// Index of the last vector entry on its storage buffer|array
+    static constexpr int32_t VECTOR_LAST_INDEX = VECTOR_NDIM - 1;
+};
 
 }  // namespace math
 }  // namespace tiny

--- a/include/tinymath/tinymath.hpp
+++ b/include/tinymath/tinymath.hpp
@@ -2,6 +2,7 @@
 
 #include <tinymath/mat4_t.hpp>
 #include <tinymath/mat4_t_impl.hpp>
+#include <tinymath/vec2_t.hpp>
 #include <tinymath/vec3_t.hpp>
 #include <tinymath/vec3_t_impl.hpp>
 #include <tinymath/vec4_t.hpp>

--- a/include/tinymath/vec2_t.hpp
+++ b/include/tinymath/vec2_t.hpp
@@ -98,8 +98,8 @@ struct Vector2 {
     }
 
     /// Returns a comma-initializer to construct the vector via its coefficients
-    auto operator<<(Scalar_T coeff) -> VecCommaInitializer<ElementType, Type> {
-        return VecCommaInitializer<ElementType, Type>(*this, coeff);
+    auto operator<<(Scalar_T coeff) -> VecCommaInitializer<Type> {
+        return VecCommaInitializer<Type>(*this, coeff);
     }
 
     /// Returns a printable string-representation of the vector

--- a/include/tinymath/vec2_t.hpp
+++ b/include/tinymath/vec2_t.hpp
@@ -26,14 +26,16 @@ namespace math {
 ///
 /// This is a class that represents a 2d-vector with entries x, y of some
 /// scalar floating-point type. Its storage is a buffer of the given scalar
-/// type, and it's aligned accordingly in order to use the aligned versions of
-/// some SIMD instructions (when using either SSE or AVX intrinsics).
+/// type; however, it's not aligned for SIMD load/store instructions (tradeoff
+/// between adding padding/size and usage of aligned load/store). So, SIMD
+/// kernels are build using unaligned load/store operations (unlike friends like
+/// vec3 and vec4 types)
 template <typename Scalar_T>
 struct Vector2 {
     /// Number of scalars used in the storage of the vector
     static constexpr uint32_t BUFFER_SIZE = 2;
     /// Number of scalar dimensions of the vector
-    static constexpr uint32_t VECTOR_NDIM = 3;
+    static constexpr uint32_t VECTOR_NDIM = 2;
 
     /// Type alias of the vector
     using Type = Vector2<Scalar_T>;
@@ -63,10 +65,108 @@ struct Vector2 {
         std::copy(values.begin(), values.end(), m_Elements.data());
     }
 
+    /// Returns a mutable reference to the x-component of the vector
+    auto x() -> Scalar_T& { return m_Elements[0]; }
+
+    /// Returns a mutable reference to the y-component of the vector
+    auto y() -> Scalar_T& { return m_Elements[1]; }
+
+    /// Returns an unmutable reference to the x-component of the vector
+    auto x() const -> const Scalar_T& { return m_Elements[0]; }
+
+    /// Returns an unmutable reference to the y-component of the vector
+    auto y() const -> const Scalar_T& { return m_Elements[1]; }
+
+    /// Returns a mutable reference to the underlying storage of the vector
+    auto elements() -> BufferType& { return m_Elements; }
+
+    /// Returns an unmutable reference to the underlying storage of the vector
+    auto elements() const -> const BufferType& { return m_Elements; }
+
+    /// Returns a pointer to the data of the underlying storage in use
+    auto data() -> Scalar_T* { return m_Elements.data(); }
+
+    /// Reeturns a const-pointer to the data of the underlying storage in use
+    auto data() const -> const Scalar_T* { return m_Elements.data(); }
+
+    /// Returns a mutable reference to the requested entry of the vector
+    auto operator[](uint32_t index) -> Scalar_T& { return m_Elements[index]; }
+
+    /// Returns an unmutable reference to the requested entry of the vector
+    auto operator[](uint32_t index) const -> const Scalar_T& {
+        return m_Elements[index];
+    }
+
+    /// Returns a printable string-representation of the vector
+    auto toString() const -> std::string {
+        std::stringstream str_result;
+        if (std::is_same<ElementType, float>()) {
+            str_result << "Vector2f(" << x() << ", " << y() << ")";
+        } else if (std::is_same<ElementType, double>()) {
+            str_result << "Vector2d(" << x() << ", " << y() << ")";
+        } else {
+            str_result << "Vector2X(" << x() << ", " << y() << ")";
+        }
+        return str_result.str();
+    }
+
+    /// Returns the number of dimensions of the vector (Vector2 <-> 2 scalars)
+    constexpr auto ndim() const -> uint32_t { return VECTOR_NDIM; }
+
+    /// Returns the number of scalars used by the storage of the vector
+    constexpr auto buffer_size() const -> uint32_t { return BUFFER_SIZE; }
+
+    /// Returns the size (in bytes) of the vector
+    static constexpr auto num_bytes_size() -> uint32_t { return sizeof(Type); }
+
+    /// Returns the alignment (in bytes) of the vector
+    static constexpr auto num_bytes_alignment() -> uint32_t {
+        return alignof(Type);
+    }
+
  private:
     /// Storage of the vector's scalars
     alignas(sizeof(Scalar_T) * BUFFER_SIZE) BufferType m_Elements = {0, 0};
 };
+
+/// \brief Prints the given vector to the given output stream
+///
+/// \tparam T Type of scalar used by the vector operand
+///
+/// \param[in,out] output_stream The output stream to write the vector to
+/// \param[in] src The vector we want to print to the output stream
+/// \returns A reference to the modified output stream (to concatenate calls)
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+auto operator<<(std::ostream& output_stream, const Vector2<T>& src)
+    -> std::ostream& {
+    output_stream << "(" << src.x() << ", " << src.y() << ")";
+    return output_stream;
+}
+
+/// \brief Reads a vector from the given input stream
+///
+/// \tparam T Type of scalar used by the vector operand
+///
+/// \param[in,out] input_stream The input stream from which to read the vector
+/// \param[out] dst The vector in which to place the read values
+/// \returns A reference to the modified input stream (to concatenate calls)
+template <typename T,
+          typename std::enable_if<IsScalar<T>::value>::type* = nullptr>
+auto operator>>(std::istream& input_stream, Vector2<T>& dst) -> std::istream& {
+    // Based on ignition-math implementation https://bit.ly/3iqAVgS
+    T x{};
+    T y{};
+
+    input_stream.setf(std::ios_base::skipws);
+    input_stream >> x >> y;
+    if (!input_stream.fail()) {
+        dst.x() = x;
+        dst.y() = y;
+    }
+
+    return input_stream;
+}
 
 }  // namespace math
 }  // namespace tiny

--- a/include/tinymath/vec2_t.hpp
+++ b/include/tinymath/vec2_t.hpp
@@ -97,6 +97,11 @@ struct Vector2 {
         return m_Elements[index];
     }
 
+    /// Returns a comma-initializer to construct the vector via its coefficients
+    auto operator<<(Scalar_T coeff) -> VecCommaInitializer<ElementType, Type> {
+        return VecCommaInitializer<ElementType, Type>(*this, coeff);
+    }
+
     /// Returns a printable string-representation of the vector
     auto toString() const -> std::string {
         std::stringstream str_result;

--- a/include/tinymath/vec2_t.hpp
+++ b/include/tinymath/vec2_t.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+// clang-format off
+#include <ios>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <initializer_list>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <algorithm>
+#include <type_traits>
+
+#include <tinymath/common.hpp>
+// clang-format on
+
+namespace tiny {
+namespace math {
+
+/// \class Vector2
+///
+/// \brief Class representation of a vector in 2d-space
+///
+/// \tparam Scalar_T Type of scalar value used for this 2d-vector (float|double)
+///
+/// This is a class that represents a 2d-vector with entries x, y of some
+/// scalar floating-point type. Its storage is a buffer of the given scalar
+/// type, and it's aligned accordingly in order to use the aligned versions of
+/// some SIMD instructions (when using either SSE or AVX intrinsics).
+template <typename Scalar_T>
+struct Vector2 {
+    /// Number of scalars used in the storage of the vector
+    static constexpr uint32_t BUFFER_SIZE = 2;
+    /// Number of scalar dimensions of the vector
+    static constexpr uint32_t VECTOR_NDIM = 3;
+
+    /// Type alias of the vector
+    using Type = Vector2<Scalar_T>;
+    /// Type alias of the scalar used for this vector (float32|64)
+    using ElementType = Scalar_T;
+    /// Type alias of the internal storage used for the vector (i.e. std::array)
+    using BufferType = std::array<Scalar_T, BUFFER_SIZE>;
+
+    /// Constructs a zero-initialized vector
+    Vector2() = default;
+
+    /// Constructs a vector of the form (x, x)
+    explicit Vector2(Scalar_T x) {
+        m_Elements[0] = x;
+        m_Elements[1] = x;
+    }
+
+    /// Constructs a vector of the form (x, y)
+    explicit Vector2(Scalar_T x, Scalar_T y) {
+        m_Elements[0] = x;
+        m_Elements[1] = y;
+    }
+
+    /// Constructs a vector from an initializer list of the form {x, y}
+    Vector2(const std::initializer_list<Scalar_T>& values) {
+        assert(values.size() == Vector2<Scalar_T>::VECTOR_NDIM);
+        std::copy(values.begin(), values.end(), m_Elements.data());
+    }
+
+ private:
+    /// Storage of the vector's scalars
+    alignas(sizeof(Scalar_T) * BUFFER_SIZE) BufferType m_Elements = {0, 0};
+};
+
+}  // namespace math
+}  // namespace tiny

--- a/include/tinymath/vec3_t.hpp
+++ b/include/tinymath/vec3_t.hpp
@@ -18,10 +18,6 @@
 namespace tiny {
 namespace math {
 
-// Forward-declare comma-initializer for vector3-types
-template <typename Scalar_T>
-class Vec3CommaInitializer;
-
 /// \class Vector3
 ///
 /// \brief Class representation of a vector in 3d-space
@@ -121,8 +117,8 @@ class Vector3 {
     }
 
     /// Returns a comma-initializer to construct the vector via its coefficients
-    auto operator<<(Scalar_T coeff) -> Vec3CommaInitializer<Scalar_T> {
-        return Vec3CommaInitializer<Scalar_T>(*this, coeff);
+    auto operator<<(Scalar_T coeff) -> VecCommaInitializer<Type> {
+        return VecCommaInitializer<Type>(*this, coeff);
     }
 
     /// Returns a printable string-representation of the vector
@@ -159,82 +155,6 @@ class Vector3 {
     /// Storage of the vector's scalars (we pad by 1 due to SIMD-alignment)
     alignas(sizeof(Scalar_T) * BUFFER_SIZE) BufferType m_Elements = {0, 0, 0,
                                                                      0};
-};
-
-/// \class Vec3CommaInitializer
-///
-/// \brief Helper class used during comma-initialization of vec3-types
-///
-/// \tparam Scalar_T Type of scalar used for the 3d vector being constructed
-///
-/// This is a helper class used for operations of the form `v << 1, 2, 3;`,
-/// which require to concatenate a comma-initializer after using the `<<`
-/// operator. This is based on Eigen's comma-initializer implementation.
-///
-/// \code
-///     Vector3d vec;
-///     vec << 1.0, 2.0, 3.0;
-/// \endcode
-template <typename Scalar_T>
-class Vec3CommaInitializer {
- public:
-    /// Number of scalar dimensions of the vector
-    constexpr static uint32_t VECTOR_NDIM = 3;
-    /// Index of the first vector entry
-    constexpr static int32_t VECTOR_FIRST_INDEX = 0;
-    /// Index of the last vector entry
-    constexpr static int32_t VECTOR_LAST_INDEX = VECTOR_NDIM - 1;
-
-    /// Type of this comma-initializer
-    using Type = Vec3CommaInitializer<Scalar_T>;
-    /// Vector type currently in use
-    using VectorType = Vector3<Scalar_T>;
-
-    /// Constructs a comma-initializer for the given vector and initial coeff.
-    // NOLINTNEXTLINE(runtime/references)
-    explicit Vec3CommaInitializer(VectorType& vec, Scalar_T coeff0)
-        : m_VectorRef(vec) {
-        // Append first coefficient to the vector
-        m_VectorRef[0] = coeff0;
-        ++m_CurrentBuildIndex;
-    }
-
-    /// Constructs a comma-initializer by copying from another one
-    Vec3CommaInitializer(const Vec3CommaInitializer<Scalar_T>& other) = default;
-
-    /// Copies the contents of a given comma-initializer
-    auto operator=(const Vec3CommaInitializer<Scalar_T>& rhs)
-        -> Vec3CommaInitializer<Scalar_T>& = default;
-
-    /// Constructs a comma-initializer by moving the ownership of another one
-    Vec3CommaInitializer(Vec3CommaInitializer<Scalar_T>&& other) noexcept =
-        default;
-
-    /// Moves the contents of a given comma-initializer
-    auto operator=(Vec3CommaInitializer<Scalar_T>&& rhs) noexcept
-        -> Vec3CommaInitializer<Scalar_T>& = default;
-
-    /// Destroys and terminates the operations of the initializer
-    ~Vec3CommaInitializer() { _finished(); }
-
-    /// Appends the given coefficient to the initializer for building the vec3
-    auto operator,(Scalar_T next_coeff) -> Type& {
-        assert(m_CurrentBuildIndex <= VECTOR_LAST_INDEX);
-        m_VectorRef[m_CurrentBuildIndex++] = next_coeff;
-        return *this;
-    }
-
- private:
-    /// Terminates the operations of the initializer
-    TM_INLINE auto _finished() -> void {
-        assert(m_CurrentBuildIndex == (VECTOR_LAST_INDEX + 1));
-    }
-
- private:
-    /// Mutable reference to the vector we're currently constructing
-    VectorType& m_VectorRef;
-    /// Index of the current coefficient being built
-    int32_t m_CurrentBuildIndex = VECTOR_FIRST_INDEX;
 };
 
 /// \brief Prints the given 3d vector to the given output stream

--- a/include/tinymath/vec4_t.hpp
+++ b/include/tinymath/vec4_t.hpp
@@ -18,10 +18,6 @@
 namespace tiny {
 namespace math {
 
-// Forward-declare comma-initializer for vector4-types
-template <typename Scalar_T>
-class Vec4CommaInitializer;
-
 /// \class Vector4
 ///
 /// \brief Class representation of a vector in 4d-space
@@ -137,8 +133,8 @@ class Vector4 {
     }
 
     /// Returns a comma-initializer to construct the vector via its coefficients
-    auto operator<<(Scalar_T coeff) -> Vec4CommaInitializer<Scalar_T> {
-        return Vec4CommaInitializer<Scalar_T>(*this, coeff);
+    auto operator<<(Scalar_T coeff) -> VecCommaInitializer<Type> {
+        return VecCommaInitializer<Type>(*this, coeff);
     }
 
     /// Returns a printable string-representation of the vector
@@ -175,82 +171,6 @@ class Vector4 {
     /// Storage of the vector's scalars
     alignas(sizeof(Scalar_T) * BUFFER_SIZE) BufferType m_Elements = {0, 0, 0,
                                                                      0};
-};
-
-/// \class Vec4CommaInitializer
-///
-/// \brief Helper class used during comma-initialization of vec4-types
-///
-/// \tparam Scalar_T Type of scalar used for the 4d vector being constructed
-///
-/// This is a helper class used for operations of the form `v << 1, 2, 3, 4;`,
-/// which require to concatenate a comma-initializer after using the `<<`
-/// operator. This is based on Eigen's comma-initializer implementation.
-///
-/// \code
-///     Vector4d vec;
-///     vec << 1.0, 2.0, 3.0, 4.0;
-/// \endcode
-template <typename Scalar_T>
-class Vec4CommaInitializer {
- public:
-    /// Number of scalar dimensions of the vector
-    constexpr static uint32_t VECTOR_NDIM = 4;
-    /// Index of the first vector entry
-    constexpr static int32_t VECTOR_FIRST_INDEX = 0;
-    /// Index of the last vector entry
-    constexpr static int32_t VECTOR_LAST_INDEX = VECTOR_NDIM - 1;
-
-    /// Type of this comma-initializer
-    using Type = Vec4CommaInitializer<Scalar_T>;
-    /// Vector type currently in use
-    using VectorType = Vector4<Scalar_T>;
-
-    /// Constructs a comma-initializer for the given vector and initial coeff.
-    // NOLINTNEXTLINE(runtime/references)
-    explicit Vec4CommaInitializer(VectorType& vec, Scalar_T coeff0)
-        : m_VectorRef(vec) {
-        // Append first coefficient to the vector
-        m_VectorRef[0] = coeff0;
-        ++m_CurrentBuildIndex;
-    }
-
-    /// Constructs a comma-initializer by copying from another one
-    Vec4CommaInitializer(const Vec4CommaInitializer<Scalar_T>& other) = default;
-
-    /// Copies the contents of a given comma-initializer
-    auto operator=(const Vec4CommaInitializer<Scalar_T>& rhs)
-        -> Vec4CommaInitializer<Scalar_T>& = default;
-
-    /// Constructs a comma-initializer by moving the ownership of another one
-    Vec4CommaInitializer(Vec4CommaInitializer<Scalar_T>&& other) noexcept =
-        default;
-
-    /// Moves the contents of a given comma-initializer
-    auto operator=(Vec4CommaInitializer<Scalar_T>&& rhs) noexcept
-        -> Vec4CommaInitializer<Scalar_T>& = default;
-
-    /// Destroys and terminates the operations of the initializer
-    ~Vec4CommaInitializer() { _finished(); }
-
-    /// Appends the given coefficient to the initializer for building the vec4
-    auto operator,(Scalar_T next_coeff) -> Type& {
-        assert(m_CurrentBuildIndex <= VECTOR_LAST_INDEX);
-        m_VectorRef[m_CurrentBuildIndex++] = next_coeff;
-        return *this;
-    }
-
- private:
-    /// Terminates the operations of the initializer
-    TM_INLINE auto _finished() -> void {
-        assert(m_CurrentBuildIndex == (VECTOR_LAST_INDEX + 1));
-    }
-
- private:
-    /// Mutable reference to the vector we're currently constructing
-    VectorType& m_VectorRef;
-    /// Index of the current coefficient being built
-    int32_t m_CurrentBuildIndex = VECTOR_FIRST_INDEX;
 };
 
 /// \brief Prints the given 4d vector to the given output stream

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ include(${CMAKE_SOURCE_DIR}/third_party/catch2/source/contrib/Catch.cmake)
 add_executable(
   TinyMathCppTests
   ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_vec2_type.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_vec3_type.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_vec3_operations.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_vec4_type.cpp

--- a/tests/cpp/test_vec2_type.cpp
+++ b/tests/cpp/test_vec2_type.cpp
@@ -1,0 +1,68 @@
+#include <catch2/catch.hpp>
+#include <cmath>
+#include <tinymath/tinymath.hpp>
+#include <type_traits>
+
+constexpr size_t N_SAMPLES = 10;
+constexpr double RANGE_MIN = -10.0;
+constexpr double RANGE_MAX = 10.0;
+
+template <typename T>
+auto FuncAllClose(const tiny::math::Vector2<T>& vec, T x, T y) -> void {
+    constexpr T EPSILON = tiny::math::EPS<T>;
+    REQUIRE(std::abs(vec.x() - x) < EPSILON);
+    REQUIRE(std::abs(vec.y() - y) < EPSILON);
+}
+
+// NOLINTNEXTLINE
+TEMPLATE_TEST_CASE("Vector2 class (vec2_t) constructors", "[vec2_t][template]",
+                   tiny::math::float32_t, tiny::math::float64_t) {
+    using T = TestType;
+    using Vector2 = tiny::math::Vector2<T>;
+
+    // Checking size and alignment (we won't do SIMD aligned load|store)
+    constexpr int EXPECTED_SIZE = 2 * sizeof(T);
+    constexpr int EXPECTED_ALIGNMENT = 2 * sizeof(T);
+    static_assert(std::is_floating_point<T>(), "");
+    static_assert(EXPECTED_SIZE == Vector2::num_bytes_size(), "");
+    static_assert(EXPECTED_ALIGNMENT == Vector2::num_bytes_alignment(), "");
+
+    // Checking the correctness of the constructors
+
+    SECTION("Default constructor") {
+        Vector2 v;
+        FuncAllClose<T>(v, 0.0, 0.0);
+    }
+
+    SECTION("From single scalar argument") {
+        auto val_x =
+            GENERATE(take(N_SAMPLES, random(static_cast<T>(RANGE_MIN),
+                                            static_cast<T>(RANGE_MAX))));
+
+        Vector2 v(val_x);
+        FuncAllClose(v, val_x, val_x);
+    }
+
+    SECTION(
+        "From two scalar arguments, from initializer_list, or using "
+        "comma-initializer") {
+        auto val_x =
+            GENERATE(take(N_SAMPLES, random(static_cast<T>(RANGE_MIN),
+                                            static_cast<T>(RANGE_MAX))));
+        auto val_y =
+            GENERATE(take(N_SAMPLES, random(static_cast<T>(RANGE_MIN),
+                                            static_cast<T>(RANGE_MAX))));
+        auto val_z =
+            GENERATE(take(N_SAMPLES, random(static_cast<T>(RANGE_MIN),
+                                            static_cast<T>(RANGE_MAX))));
+
+        Vector2 v_1(val_x, val_y);
+        Vector2 v_2 = {val_x, val_y};
+        //// Vector2 v_3;
+        //// v_3 << val_x, val_y;
+
+        FuncAllClose(v_1, val_x, val_y);
+        FuncAllClose(v_2, val_x, val_y);
+        //// FuncAllClose(v_3, val_x, val_y);
+    }
+}

--- a/tests/cpp/test_vec2_type.cpp
+++ b/tests/cpp/test_vec2_type.cpp
@@ -58,11 +58,11 @@ TEMPLATE_TEST_CASE("Vector2 class (vec2_t) constructors", "[vec2_t][template]",
 
         Vector2 v_1(val_x, val_y);
         Vector2 v_2 = {val_x, val_y};
-        //// Vector2 v_3;
-        //// v_3 << val_x, val_y;
+        Vector2 v_3;
+        v_3 << val_x, val_y;
 
         FuncAllClose(v_1, val_x, val_y);
         FuncAllClose(v_2, val_x, val_y);
-        //// FuncAllClose(v_3, val_x, val_y);
+        FuncAllClose(v_3, val_x, val_y);
     }
 }


### PR DESCRIPTION
## Description
Implemens the base functionality for `vec2_t` types (similar to `vec3_t` and `vec4_t`)

**Note**: Operations will be added in a separate PR