### PR TITLE
Adds support for both Scalar and SIMD operations on vec2 types

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 # List of all examples to be built
 set(TINYMATH_EXAMPLES_LIST
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec2_constructors.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/example_vec2_operations.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec3_constructors.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec3_operations.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/example_vec4_constructors.cpp

--- a/examples/cpp/example_vec2_operations.cpp
+++ b/examples/cpp/example_vec2_operations.cpp
@@ -1,0 +1,48 @@
+#include <tinymath/tinymath.hpp>
+#include <type_traits>
+
+template <typename T, typename = typename std::enable_if<
+                          tiny::math::IsScalar<T>::value>::type>
+auto run_operations_vec2() -> void {
+    using Vec2 = tiny::math::Vector2<T>;
+
+    // Preamble (show the type we're currently working with)
+    if (std::is_same<T, float>()) {
+        std::cout << "Vector2-float32 type:\n";
+    } else if (std::is_same<T, double>()) {
+        std::cout << "Vector2-float64 type:\n";
+    }
+
+    Vec2 vec_a(1.0, 2.0);
+    Vec2 vec_b(3.0, 5.0);
+
+    Vec2 vec_sum = vec_a + vec_b;
+    Vec2 vec_diff = vec_a - vec_b;
+    Vec2 vec_scale_1 = static_cast<T>(2.5) * vec_a;
+    Vec2 vec_scale_2 = vec_b * static_cast<T>(0.25);
+    Vec2 vec_mul = vec_a * vec_b;
+
+    std::cout << "a: " << '\n' << vec_a.toString() << '\n';
+    std::cout << "b: " << '\n' << vec_b.toString() << '\n';
+    std::cout << "a + b: " << '\n' << vec_sum.toString() << '\n';
+    std::cout << "a - b: " << '\n' << vec_diff.toString() << '\n';
+    std::cout << "2.5 * a: " << '\n' << vec_scale_1.toString() << '\n';
+    std::cout << "b * 0.25: " << '\n' << vec_scale_2.toString() << '\n';
+    std::cout << "a . b: " << '\n' << tiny::math::dot(vec_a, vec_b) << '\n';
+    std::cout << "b . a: " << '\n' << tiny::math::dot(vec_b, vec_a) << '\n';
+    std::cout << "|a|: " << '\n' << tiny::math::norm(vec_a) << '\n';
+    std::cout << "|a|^2: " << '\n' << tiny::math::squareNorm(vec_a) << '\n';
+    std::cout << "|b|: " << '\n' << tiny::math::norm(vec_b) << '\n';
+    std::cout << "|b|^2: " << '\n' << tiny::math::squareNorm(vec_b) << '\n';
+    std::cout << "a * b: " << '\n' << vec_mul.toString() << '\n';
+    std::cout << "a == b: " << '\n'
+              << ((vec_a == vec_b) ? "True" : "False") << '\n';
+    std::cout << "a != b: " << '\n'
+              << ((vec_a != vec_b) ? "True" : "False") << '\n';
+}
+
+auto main() -> int {
+    run_operations_vec2<float>();
+    run_operations_vec2<double>();
+    return 0;
+}

--- a/include/tinymath/impl/vec2_t_avx_impl.hpp
+++ b/include/tinymath/impl/vec2_t_avx_impl.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/include/tinymath/impl/vec2_t_avx_impl.hpp
+++ b/include/tinymath/impl/vec2_t_avx_impl.hpp
@@ -1,1 +1,0 @@
-#pragma once

--- a/include/tinymath/impl/vec2_t_scalar_impl.hpp
+++ b/include/tinymath/impl/vec2_t_scalar_impl.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cmath>
+#include <tinymath/vec2_t.hpp>
+
+namespace tiny {
+namespace math {
+namespace scalar {
+
+template <typename T>
+using Vec2Buffer = typename Vector2<T>::BufferType;
+
+template <typename T>
+constexpr auto COMPILE_TIME_CHECKS_VEC2_SCALAR() -> int {
+    static_assert(Vector2<T>::BUFFER_SIZE == 2,
+                  "Must use 2 elements for the internal buffer");
+    static_assert(Vector2<T>::VECTOR_NDIM == 2,
+                  "Must use 2 elements for the vector elements");
+    static_assert(
+        sizeof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
+        "Must use exactly this many bytes of storage");
+    static_assert(
+        alignof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
+        "Must be aligned to its corresponding size");
+    return 0;
+}
+
+template <typename T>
+using SFINAE_VEC2_SCALAR_GUARD =
+    typename std::enable_if<IsScalar<T>::value>::type*;
+
+template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
+                               const Vec2Buffer<T>& rhs) -> void {
+    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
+    for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
+        dst[i] = lhs[i] + rhs[i];
+    }
+}
+
+template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_sub_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
+                               const Vec2Buffer<T>& rhs) -> void {
+    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
+    for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
+        dst[i] = lhs[i] - rhs[i];
+    }
+}
+
+template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_scale_vec2(Vec2Buffer<T>& dst, T scale,
+                                 const Vec2Buffer<T>& vec) -> void {
+    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
+    for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
+        dst[i] = scale * vec[i];
+    }
+}
+
+template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_hadamard_vec2(Vec2Buffer<T>& dst,
+                                    const Vec2Buffer<T>& lhs,
+                                    const Vec2Buffer<T>& rhs) -> void {
+    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
+    for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
+        dst[i] = lhs[i] * rhs[i];
+    }
+}
+
+template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_length_square_vec2(const Vec2Buffer<T>& vec) -> T {
+    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
+    T accum = static_cast<T>(0.0);
+    for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
+        accum += vec[i] * vec[i];
+    }
+    return accum;
+}
+
+template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_normalize_in_place_vec2(Vec2Buffer<T>& vec) -> void {
+    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
+    auto length = std::sqrt(kernel_length_square_vec2<T>(vec));
+    for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
+        vec[i] /= length;
+    }
+}
+
+template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_dot_vec2(const Vec2Buffer<T>& lhs,
+                               const Vec2Buffer<T>& rhs) -> T {
+    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
+    T accum = static_cast<T>(0.0);
+    for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
+        accum += lhs[i] * rhs[i];
+    }
+    return accum;
+}
+
+template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
+TM_INLINE auto kernel_compare_eq_vec2(const Vec2Buffer<T>& lhs,
+                                      const Vec2Buffer<T>& rhs) -> bool {
+    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
+    for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
+        if (std::abs(lhs[i] - rhs[i]) >= tiny::math::EPS<T>) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace scalar
+}  // namespace math
+}  // namespace tiny

--- a/include/tinymath/impl/vec2_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec2_t_sse_impl.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/include/tinymath/impl/vec2_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec2_t_sse_impl.hpp
@@ -1,1 +1,249 @@
 #pragma once
+
+#if defined(TINYMATH_SSE_ENABLED)
+
+#include <emmintrin.h>
+#include <smmintrin.h>
+#include <xmmintrin.h>
+
+#include <tinymath/vec2_t.hpp>
+
+/**
+ * SSE instruction sets required for each kernel:
+ *
+ * - kernel_add_vec3                : SSE|SSE2
+ * - kernel_sub_vec3                : SSE|SSE2
+ * - kernel_scale_vec3              : SSE|SSE2
+ * - kernel_hadamard_vec3           : SSE|SSE2
+ * - kernel_length_square_vec3      : SSE|SSE2|SSE4.1
+ * - kernel_length_vec3             : SSE|SSE2|SSE4.1
+ * - kernel_normalize_in_place_vec3 : SSE|SSE2|SSE4.1
+ * - kernel_dot_vec3                : SSE|SSE2|SSE4.1
+ * - kernel_cross_vec3              : SSE
+ *
+ * Notes:
+ * 1. For SSE-float32:
+ *  - @note(wilbert): data is not aligned to the width of an xmm-register, so
+ *      we use the unaligned version of the load/store intrinsic functions
+ *  - @note(wilbert): data buffer is smaller than the width of an xmm register,
+ *      which might load 8 bytes not related to the vector. This might be ok;
+ *      however, for stores we need to only touch 2 floats, or else we'll
+ *      corrupt 2 bytes from any object that might be allocated right next to it
+ *
+ * 2. For SSE-float64:
+ *  - @note(wilbert): All elements of the buffer (2xf64) fit into a single xmm
+ *      register (128-bits <=> 2xfloat64)
+ */
+
+namespace tiny {
+namespace math {
+namespace sse {
+
+template <typename T>
+using Vec2Buffer = typename Vector2<T>::BufferType;
+
+template <typename T>
+constexpr auto COMPILE_TIME_CHECKS_VEC2_F32_SSE() -> int {
+    static_assert(std::is_same<float, T>::value, "Must be using f32");
+    static_assert(Vector2<T>::BUFFER_SIZE == 2,
+                  "Must be using 2xf32 as aligned buffer");
+    static_assert(Vector2<T>::VECTOR_NDIM == 2,
+                  "Must be using 2xf32 for the elements of the vector");
+    static_assert(
+        sizeof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
+        "Must use exactly this many bytes of storage");
+    static_assert(
+        alignof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
+        "Must be aligned to its corresponding size");
+    return 0;
+}
+
+template <typename T>
+constexpr auto COMPILE_TIME_CHECKS_VEC2_F64_SSE() -> int {
+    static_assert(std::is_same<double, T>::value, "Must be using f64");
+    static_assert(Vector2<T>::BUFFER_SIZE == 2,
+                  "Must be using 2xf64 as aligned buffer");
+    static_assert(Vector2<T>::VECTOR_NDIM == 2,
+                  "Must be using 2xf64 for the elements of the vector");
+    static_assert(
+        sizeof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
+        "Must use exactly this many bytes of storage");
+    static_assert(
+        alignof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
+        "Must be aligned to its corresponding size");
+    return 0;
+}
+
+template <typename T>
+using SFINAE_VEC2_F32_SSE_GUARD =
+    typename std::enable_if<CpuHasSSE<T>::value && IsFloat32<T>::value>::type*;
+
+template <typename T>
+using SFINAE_VEC2_F64_SSE_GUARD =
+    typename std::enable_if<CpuHasSSE<T>::value && IsFloat64<T>::value>::type*;
+
+template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
+                               const Vec2Buffer<T>& rhs) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
+    auto xmm_lhs = _mm_loadu_ps(lhs.data());
+    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
+    _mm_storel_pi(reinterpret_cast<__m64*>(dst.data()), xmm_result);  // NOLINT
+}
+
+template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
+                               const Vec2Buffer<T>& rhs) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
+    auto xmm_lhs = _mm_loadu_pd(lhs.data());
+    auto xmm_rhs = _mm_loadu_pd(rhs.data());
+    auto xmm_result = _mm_add_pd(xmm_lhs, xmm_rhs);
+    _mm_storeu_pd(dst.data(), xmm_result);
+}
+
+template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_sub_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
+                               const Vec2Buffer<T>& rhs) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
+    auto xmm_lhs = _mm_loadu_ps(lhs.data());
+    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
+    _mm_storel_pi(reinterpret_cast<__m64*>(dst.data()), xmm_result);  // NOLINT
+}
+
+template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_sub_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
+                               const Vec2Buffer<T>& rhs) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
+    auto xmm_lhs = _mm_loadu_pd(lhs.data());
+    auto xmm_rhs = _mm_loadu_pd(rhs.data());
+    auto xmm_result = _mm_sub_pd(xmm_lhs, xmm_rhs);
+    _mm_storeu_pd(dst.data(), xmm_result);
+}
+
+template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_scale_vec2(Vec2Buffer<T>& dst, T scale,
+                                 const Vec2Buffer<T>& vec) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
+    auto xmm_scale = _mm_set1_ps(scale);
+    auto xmm_vector = _mm_loadu_ps(vec.data());
+    auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
+    _mm_storel_pi(reinterpret_cast<__m64*>(dst.data()), xmm_result);  // NOLINT
+}
+
+template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_scale_vec2(Vec2Buffer<T>& dst, T scale,
+                                 const Vec2Buffer<T>& vec) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
+    auto xmm_scale = _mm_set1_pd(scale);
+    auto xmm_vector = _mm_loadu_pd(vec.data());
+    auto xmm_result = _mm_mul_pd(xmm_scale, xmm_vector);
+    _mm_storeu_pd(dst.data(), xmm_result);
+}
+
+template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_hadamard_vec2(Vec2Buffer<T>& dst,
+                                    const Vec2Buffer<T>& lhs,
+                                    const Vec2Buffer<T>& rhs) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
+    auto xmm_lhs = _mm_loadu_ps(lhs.data());
+    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_result = _mm_mul_ps(xmm_lhs, xmm_rhs);
+    _mm_storel_pi(reinterpret_cast<__m64*>(dst.data()), xmm_result);  // NOLINT
+}
+
+template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_hadamard_vec2(Vec2Buffer<T>& dst,
+                                    const Vec2Buffer<T>& lhs,
+                                    const Vec2Buffer<T>& rhs) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
+    auto xmm_lhs = _mm_loadu_pd(lhs.data());
+    auto xmm_rhs = _mm_loadu_pd(rhs.data());
+    auto xmm_result = _mm_mul_pd(xmm_lhs, xmm_rhs);
+    _mm_storeu_pd(dst.data(), xmm_result);
+}
+
+template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_length_square_vec2(const Vec2Buffer<T>& vec) -> T {
+    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
+    // Implementation based on this post: https://bit.ly/3FyZF0n
+    auto xmm_v = _mm_loadu_ps(vec.data());
+    auto xmm_square_sum = _mm_dp_ps(xmm_v, xmm_v, 0x31);
+    return _mm_cvtss_f32(xmm_square_sum);
+}
+
+template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_length_square_vec2(const Vec2Buffer<T>& vec) -> T {
+    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
+    // Implementation based on this post: https://bit.ly/3FyZF0n
+    auto xmm_v = _mm_loadu_pd(vec.data());
+    auto xmm_square_sum = _mm_dp_pd(xmm_v, xmm_v, 0x31);
+    return _mm_cvtsd_f64(xmm_square_sum);
+}
+
+template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_length_vec2(const Vec2Buffer<T>& vec) -> T {
+    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
+    // Implementation based on this post: https://bit.ly/3FyZF0n
+    auto xmm_v = _mm_loadu_ps(vec.data());
+    auto xmm_square_sum = _mm_dp_ps(xmm_v, xmm_v, 0x31);
+    return _mm_cvtss_f32(_mm_sqrt_ss(xmm_square_sum));
+}
+
+template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_length_vec2(const Vec2Buffer<T>& vec) -> T {
+    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
+    // Implementation based on this post: https://bit.ly/3FyZF0n
+    auto xmm_v = _mm_loadu_pd(vec.data());
+    auto xmm_square_sum = _mm_dp_pd(xmm_v, xmm_v, 0x31);
+    return _mm_cvtsd_f64(_mm_sqrt_sd(xmm_square_sum, xmm_square_sum));
+}
+
+template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_normalize_in_place_vec2(Vec2Buffer<T>& vec) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
+    // Implementation based on this post: https://bit.ly/3FyZF0n
+    auto xmm_v = _mm_loadu_ps(vec.data());
+    auto xmm_sums = _mm_dp_ps(xmm_v, xmm_v, 0x3f);
+    auto xmm_r_sqrt_sums = _mm_sqrt_ps(xmm_sums);
+    auto xmm_v_norm = _mm_div_ps(xmm_v, xmm_r_sqrt_sums);
+    _mm_storel_pi(reinterpret_cast<__m64*>(vec.data()), xmm_v_norm);  // NOLINT
+}
+
+template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_normalize_in_place_vec2(Vec2Buffer<T>& vec) -> void {
+    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
+    // Implementation based on this post: https://bit.ly/3FyZF0n
+    auto xmm_v = _mm_loadu_pd(vec.data());
+    auto xmm_sums = _mm_dp_pd(xmm_v, xmm_v, 0x33);
+    auto xmm_r_sqrt_sums = _mm_sqrt_pd(xmm_sums);
+    auto xmm_v_norm = _mm_div_pd(xmm_v, xmm_r_sqrt_sums);
+    _mm_storeu_pd(vec.data(), xmm_v_norm);
+}
+
+template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_dot_vec2(const Vec2Buffer<T>& lhs,
+                               const Vec2Buffer<T>& rhs) -> T {
+    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
+    auto xmm_lhs = _mm_loadu_ps(lhs.data());
+    auto xmm_rhs = _mm_loadu_ps(rhs.data());
+    auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0x31);
+    return _mm_cvtss_f32(xmm_cond_prod);
+}
+
+template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
+TM_INLINE auto kernel_dot_vec2(const Vec2Buffer<T>& lhs,
+                               const Vec2Buffer<T>& rhs) -> T {
+    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
+    auto xmm_lhs = _mm_loadu_pd(lhs.data());
+    auto xmm_rhs = _mm_loadu_pd(rhs.data());
+    auto xmm_dot = _mm_dp_pd(xmm_lhs, xmm_rhs, 0x31);
+    return _mm_cvtsd_f64(xmm_dot);
+}
+
+}  // namespace sse
+}  // namespace math
+}  // namespace tiny
+
+#endif  // TINYMATH_SSE_ENABLED

--- a/include/tinymath/impl/vec2_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec2_t_sse_impl.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_SSE_ENABLED) || defined(TINYMATH_AVX_ENABLED)
 
 #include <emmintrin.h>
 #include <smmintrin.h>
@@ -33,6 +33,8 @@
  * 2. For SSE-float64:
  *  - @note(wilbert): All elements of the buffer (2xf64) fit into a single xmm
  *      register (128-bits <=> 2xfloat64)
+ *
+ * 3. Note that we're using the same SSE kernels for the AVX versions
  */
 
 namespace tiny {
@@ -76,11 +78,13 @@ constexpr auto COMPILE_TIME_CHECKS_VEC2_F64_SSE() -> int {
 
 template <typename T>
 using SFINAE_VEC2_F32_SSE_GUARD =
-    typename std::enable_if<CpuHasSSE<T>::value && IsFloat32<T>::value>::type*;
+    typename std::enable_if<(CpuHasSSE<T>::value || CpuHasAVX<T>::value) &&
+                            IsFloat32<T>::value>::type*;
 
 template <typename T>
 using SFINAE_VEC2_F64_SSE_GUARD =
-    typename std::enable_if<CpuHasSSE<T>::value && IsFloat64<T>::value>::type*;
+    typename std::enable_if<(CpuHasSSE<T>::value || CpuHasAVX<T>::value) &&
+                            IsFloat64<T>::value>::type*;
 
 template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
@@ -246,4 +250,4 @@ TM_INLINE auto kernel_dot_vec2(const Vec2Buffer<T>& lhs,
 }  // namespace math
 }  // namespace tiny
 
-#endif  // TINYMATH_SSE_ENABLED
+#endif  // TINYMATH_SSE_ENABLED || TINYMATH_AVX_ENABLED

--- a/include/tinymath/tinymath.hpp
+++ b/include/tinymath/tinymath.hpp
@@ -3,6 +3,7 @@
 #include <tinymath/mat4_t.hpp>
 #include <tinymath/mat4_t_impl.hpp>
 #include <tinymath/vec2_t.hpp>
+#include <tinymath/vec2_t_impl.hpp>
 #include <tinymath/vec3_t.hpp>
 #include <tinymath/vec3_t_impl.hpp>
 #include <tinymath/vec4_t.hpp>

--- a/include/tinymath/vec2_t_impl.hpp
+++ b/include/tinymath/vec2_t_impl.hpp
@@ -1,0 +1,245 @@
+#pragma once
+
+// clang-format off
+#include <tinymath/vec2_t.hpp>
+#include <tinymath/impl/vec2_t_scalar_impl.hpp>
+#include <tinymath/impl/vec2_t_sse_impl.hpp>
+#include <tinymath/impl/vec2_t_avx_impl.hpp>
+// clang-format on
+
+namespace tiny {
+namespace math {
+
+template <typename T>
+using SFINAE_VEC2_GUARD = typename std::enable_if<IsScalar<T>::value>::type*;
+
+/// \brief Returns the square of the norm-2 of the vector
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto squareNorm(const Vector2<T>& vec) -> T {
+#if defined(TINYMATH_AVX_ENABLED)
+    return avx::kernel_length_square_vec2<T>(vec.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    return sse::kernel_length_square_vec2<T>(vec.elements());
+#else
+    return scalar::kernel_length_square_vec2<T>(vec.elements());
+#endif
+}
+
+/// \brief Returns the norm-2 of the vector
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto norm(const Vector2<T>& vec) -> T {
+#if defined(TINYMATH_AVX_ENABLED)
+    return avx::kernel_length_vec2<T>(vec.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    return sse::kernel_length_vec2<T>(vec.elements());
+#else
+    return std::sqrt(scalar::kernel_length_square_vec2<T>(vec.elements()));
+#endif
+}
+
+/// \brief Returns a normalized version of this vector
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto normalize(const Vector2<T>& vec) -> Vector2<T> {
+    Vector2<T> vec_normalized = vec;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_normalize_in_place_vec2<T>(vec_normalized.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_normalize_in_place_vec2<T>(vec_normalized.elements());
+#else
+    scalar::kernel_normalize_in_place_vec2<T>(vec_normalized.elements());
+#endif
+    return vec_normalized;
+}
+
+/// \brief Normalizes in-place the given vector
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto normalize_in_place(Vector2<T>& vec) -> void {  // NOLINT
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_normalize_in_place_vec2<T>(vec.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_normalize_in_place_vec2<T>(vec.elements());
+#else
+    scalar::kernel_normalize_in_place_vec2<T>(vec.elements());
+#endif
+}
+
+/// \brief Returns the dot-product of the given two vectors
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto dot(const Vector2<T>& lhs, const Vector2<T>& rhs) -> T {
+#if defined(TINYMATH_AVX_ENABLED)
+    return avx::kernel_dot_vec2<T>(lhs.elements(), rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    return sse::kernel_dot_vec2<T>(lhs.elements(), rhs.elements());
+#else
+    return scalar::kernel_dot_vec2<T>(lhs.elements(), rhs.elements());
+#endif
+}
+
+/// \brief Returns the vector-sum of two 3d vector operands
+///
+/// \tparam T Type of scalar value used for the 3d-vector operands
+///
+/// This operator implements an element-wise sum of two Vector2 operands given
+/// as input arguments. The internal operator selects the appropriate "kernel"
+/// (just a function) to which to call, depending on whether or not the library
+/// was compiled using SIMD support (i.e. SSE and AVX function intrinsics will
+/// be used to handle the operation).
+///
+/// \param[in] lhs Left-hand-side operand of the vector-sum
+/// \param[in] rhs Right-hand-side operand of the vector-sum
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto operator+(const Vector2<T>& lhs, const Vector2<T>& rhs)
+    -> Vector2<T> {
+    Vector2<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_add_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_add_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
+#else
+    scalar::kernel_add_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
+#endif
+    return dst;
+}
+
+/// \brief Returns the vector-difference of two 3d vector operands
+///
+/// \tparam T Type of scalar value used for the 3d-vector operands
+///
+/// This operator implements an element-wise difference of two Vector2 operands
+/// given as input arguments. The internal operator selects the appropriate
+/// "kernel" (just a function) to which to call, depending on whether or not the
+/// library was compiled using SIMD support (i.e. SSE and AVX function
+/// intrinsics will be used to handle the operation).
+///
+/// \param[in] lhs Left-hand-side operand of the vector-sum
+/// \param[in] rhs Right-hand-side operand of the vector-sum
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto operator-(const Vector2<T>& lhs, const Vector2<T>& rhs)
+    -> Vector2<T> {
+    Vector2<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_sub_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_sub_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
+#else
+    scalar::kernel_sub_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
+#endif
+    return dst;
+}
+
+/// \brief Returns the scalar-vector product of a scalar and 3d vector operands
+///
+/// \tparam T Type of scalar used by both scalar and vector operands
+///
+/// This operator implements the scalar-vector product of two operands (a scalar
+/// and a vector in that order) given as input arguments. The internal operator
+/// selects the appropriate "kernel" (just a function) to which to call,
+/// depending on whether or not the library was compiled using SIMD support
+/// (i.e. SSE and AVX function intrinsics will be used to handle the operation).
+///
+/// \param[in] scale Scalar value by which to scale the second operand
+/// \param[in] vec Vector in 3d-space which we want to scale
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto operator*(T scale, const Vector2<T>& vec) -> Vector2<T> {
+    Vector2<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
+#else
+    scalar::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
+#endif
+    return dst;
+}
+
+/// \brief Returns the vector-scalar product of a 3d vector and scalar operands
+///
+/// \tparam T Type of scalar used by both vector and scalar operands
+///
+/// This operator implements the vector-scalar product of two operands (a vector
+/// and a scalar in that order) given as input arguments. The internal operator
+/// selects the appropriate "kernel" (just a function) to which to call,
+/// depending on whether or not the library was compiled using SIMD support
+/// (i.e. SSE and AVX function intrinsics will be used to handle the operation).
+///
+/// \param[in] vec Vector in 3d-space which we want to scale
+/// \param[in] scale Scalar value by which to scale the first operand
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto operator*(const Vector2<T>& vec, T scale) -> Vector2<T> {
+    Vector2<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
+#else
+    scalar::kernel_scale_vec2(dst.elements(), scale, vec.elements());
+#endif
+    return dst;
+}
+
+/// \brief Returns the element-wise product of two 3d vector operands
+///
+/// \tparam T Type of scalar value used by the 3d-vector operands
+///
+/// This operator implements an element-wise product (Hadamard-Schur product) of
+/// two Vector2 operands given as input arguments. The internal operator selects
+/// the appropriate "kernel" (just a function) to which to call, depending on
+/// whether or not the library was compiled using SIMD support (i.e. SSE and AVX
+/// function intrinsics will be used to handle the operation).
+///
+/// \param[in] lhs Left-hand-side operand of the element-wise product
+/// \param[in] rhs Right-hand-side operand of the element-wise product
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto operator*(const Vector2<T>& lhs, const Vector2<T>& rhs)
+    -> Vector2<T> {
+    Vector2<T> dst;
+#if defined(TINYMATH_AVX_ENABLED)
+    avx::kernel_hadamard_vec2<T>(dst.elements(), lhs.elements(),
+                                 rhs.elements());
+#elif defined(TINYMATH_SSE_ENABLED)
+    sse::kernel_hadamard_vec2<T>(dst.elements(), lhs.elements(),
+                                 rhs.elements());
+#else
+    scalar::kernel_hadamard_vec2<T>(dst.elements(), lhs.elements(),
+                                    rhs.elements());
+#endif
+    return dst;
+}
+
+/// \brief Checks if two given vectors are "equal" (within epsilon margin)
+///
+/// \tparam T Type of scalar value used by the 3d-vector operands
+///
+/// This operator implements an "np.allclose"-like operation (numpy's allclose
+/// function), checking if the corresponding (x,y,z) entries of both operands
+/// are within a certain margin "epsilon" (pre-defined constant). There was an
+/// "equal"-like SIMD instruction that implements floating point comparisons,
+/// however, we're not using it as single-precision floating point operations
+/// and transformation functions within the library might result in compounding
+/// errors that the user might want to test a small margin of error tuned
+/// appropriately (specially for single-precision floating point types)
+///
+/// \param[in] lhs Left-hand-side operand of the comparison
+/// \param[in] rhs Right-hand-side operand of the comparison
+/// \returns true if the given vectors are within a pre-defined epsilon margin
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto operator==(const Vector2<T>& lhs, const Vector2<T>& rhs)
+    -> bool {
+    return scalar::kernel_compare_eq_vec2<T>(lhs.elements(), rhs.elements());
+}
+
+/// \brief Checks if two given vectors are not "equal" (within epsilon margin)
+///
+/// \tparam T Type of scalar value used by the 3d-vector operands
+///
+/// \param[in] lhs Left-hand-side operand of the comparison
+/// \param[in] rhs Right-hand-side operand of the comparison
+/// \returns true if the given vectors are not within a pre-defined margin
+template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
+TM_INLINE auto operator!=(const Vector2<T>& lhs, const Vector2<T>& rhs)
+    -> bool {
+    return !scalar::kernel_compare_eq_vec2<T>(lhs.elements(), rhs.elements());
+}
+
+}  // namespace math
+}  // namespace tiny

--- a/include/tinymath/vec2_t_impl.hpp
+++ b/include/tinymath/vec2_t_impl.hpp
@@ -4,7 +4,6 @@
 #include <tinymath/vec2_t.hpp>
 #include <tinymath/impl/vec2_t_scalar_impl.hpp>
 #include <tinymath/impl/vec2_t_sse_impl.hpp>
-#include <tinymath/impl/vec2_t_avx_impl.hpp>
 // clang-format on
 
 namespace tiny {
@@ -16,9 +15,7 @@ using SFINAE_VEC2_GUARD = typename std::enable_if<IsScalar<T>::value>::type*;
 /// \brief Returns the square of the norm-2 of the vector
 template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto squareNorm(const Vector2<T>& vec) -> T {
-#if defined(TINYMATH_AVX_ENABLED)
-    return avx::kernel_length_square_vec2<T>(vec.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     return sse::kernel_length_square_vec2<T>(vec.elements());
 #else
     return scalar::kernel_length_square_vec2<T>(vec.elements());
@@ -28,9 +25,7 @@ TM_INLINE auto squareNorm(const Vector2<T>& vec) -> T {
 /// \brief Returns the norm-2 of the vector
 template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto norm(const Vector2<T>& vec) -> T {
-#if defined(TINYMATH_AVX_ENABLED)
-    return avx::kernel_length_vec2<T>(vec.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     return sse::kernel_length_vec2<T>(vec.elements());
 #else
     return std::sqrt(scalar::kernel_length_square_vec2<T>(vec.elements()));
@@ -41,9 +36,7 @@ TM_INLINE auto norm(const Vector2<T>& vec) -> T {
 template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto normalize(const Vector2<T>& vec) -> Vector2<T> {
     Vector2<T> vec_normalized = vec;
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_normalize_in_place_vec2<T>(vec_normalized.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     sse::kernel_normalize_in_place_vec2<T>(vec_normalized.elements());
 #else
     scalar::kernel_normalize_in_place_vec2<T>(vec_normalized.elements());
@@ -54,9 +47,7 @@ TM_INLINE auto normalize(const Vector2<T>& vec) -> Vector2<T> {
 /// \brief Normalizes in-place the given vector
 template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto normalize_in_place(Vector2<T>& vec) -> void {  // NOLINT
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_normalize_in_place_vec2<T>(vec.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     sse::kernel_normalize_in_place_vec2<T>(vec.elements());
 #else
     scalar::kernel_normalize_in_place_vec2<T>(vec.elements());
@@ -66,9 +57,7 @@ TM_INLINE auto normalize_in_place(Vector2<T>& vec) -> void {  // NOLINT
 /// \brief Returns the dot-product of the given two vectors
 template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto dot(const Vector2<T>& lhs, const Vector2<T>& rhs) -> T {
-#if defined(TINYMATH_AVX_ENABLED)
-    return avx::kernel_dot_vec2<T>(lhs.elements(), rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     return sse::kernel_dot_vec2<T>(lhs.elements(), rhs.elements());
 #else
     return scalar::kernel_dot_vec2<T>(lhs.elements(), rhs.elements());
@@ -91,9 +80,7 @@ template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto operator+(const Vector2<T>& lhs, const Vector2<T>& rhs)
     -> Vector2<T> {
     Vector2<T> dst;
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_add_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     sse::kernel_add_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
 #else
     scalar::kernel_add_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
@@ -117,9 +104,7 @@ template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto operator-(const Vector2<T>& lhs, const Vector2<T>& rhs)
     -> Vector2<T> {
     Vector2<T> dst;
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_sub_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     sse::kernel_sub_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
 #else
     scalar::kernel_sub_vec2<T>(dst.elements(), lhs.elements(), rhs.elements());
@@ -142,9 +127,7 @@ TM_INLINE auto operator-(const Vector2<T>& lhs, const Vector2<T>& rhs)
 template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto operator*(T scale, const Vector2<T>& vec) -> Vector2<T> {
     Vector2<T> dst;
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     sse::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
 #else
     scalar::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
@@ -167,9 +150,7 @@ TM_INLINE auto operator*(T scale, const Vector2<T>& vec) -> Vector2<T> {
 template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto operator*(const Vector2<T>& vec, T scale) -> Vector2<T> {
     Vector2<T> dst;
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     sse::kernel_scale_vec2<T>(dst.elements(), scale, vec.elements());
 #else
     scalar::kernel_scale_vec2(dst.elements(), scale, vec.elements());
@@ -193,10 +174,7 @@ template <typename T, SFINAE_VEC2_GUARD<T> = nullptr>
 TM_INLINE auto operator*(const Vector2<T>& lhs, const Vector2<T>& rhs)
     -> Vector2<T> {
     Vector2<T> dst;
-#if defined(TINYMATH_AVX_ENABLED)
-    avx::kernel_hadamard_vec2<T>(dst.elements(), lhs.elements(),
-                                 rhs.elements());
-#elif defined(TINYMATH_SSE_ENABLED)
+#if defined(TINYMATH_AVX_ENABLED) || defined(TINYMATH_SSE_ENABLED)
     sse::kernel_hadamard_vec2<T>(dst.elements(), lhs.elements(),
                                  rhs.elements());
 #else

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   TinyMathCppTests
   ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_vec2_type.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_vec2_operations.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_vec3_type.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_vec3_operations.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_vec4_type.cpp

--- a/tests/cpp/test_vec2_operations.cpp
+++ b/tests/cpp/test_vec2_operations.cpp
@@ -1,0 +1,176 @@
+#include <catch2/catch.hpp>
+#include <tinymath/tinymath.hpp>
+
+template <typename T>
+constexpr auto FuncClose(T a, T b, T eps) -> bool {
+    return ((a - b) < eps) && ((a - b) > -eps);
+}
+
+template <typename T>
+constexpr auto FuncCompareEqual(T xa, T ya, T xb, T yb, T eps) -> bool {
+    return FuncClose<T>(xa, xb, eps) && FuncClose<T>(ya, yb, eps);
+}
+
+// NOLINTNEXTLINE
+TEMPLATE_TEST_CASE("Vector2 class (vec2_t) core Operations", "[vec2_t][ops]",
+                   tiny::math::float32_t, tiny::math::float64_t) {
+    using T = TestType;
+    using Vector2 = tiny::math::Vector2<T>;
+
+    constexpr T EPSILON = tiny::math::EPS<T>;
+
+    SECTION("Vector comparison ==, !=") {
+        Vector2 v_1(1.0, 2.0);  // NOLINT
+        Vector2 v_2(1.0, 2.0);  // NOLINT
+        Vector2 v_3(1.1, 2.1);  // NOLINT
+
+        REQUIRE(v_1 == v_2);
+        REQUIRE(v_2 != v_3);
+        REQUIRE(v_3 != v_1);
+
+        auto val_x_a = GENERATE(as<T>{}, 1.0, 2.0);  // NOLINT
+        auto val_y_a = GENERATE(as<T>{}, 2.0, 4.0);  // NOLINT
+
+        auto val_x_b = GENERATE(as<T>{}, 0.5, 0.25);  // NOLINT
+        auto val_y_b = GENERATE(as<T>{}, 1.0, 1.25);  // NOLINT
+
+        Vector2 v_a(val_x_a, val_y_a);
+        Vector2 v_b(val_x_b, val_y_b);
+
+        auto equal_a_b_lib = (v_a == v_b);
+        auto equal_a_b_man =
+            FuncCompareEqual<T>(val_x_a, val_y_a, val_x_b, val_y_b, EPSILON);
+
+        auto diff_a_b_lib = (v_a != v_b);
+        auto diff_a_b_man = !equal_a_b_man;
+
+        REQUIRE(equal_a_b_lib == equal_a_b_man);
+        REQUIRE(diff_a_b_lib == diff_a_b_man);
+    }
+
+    SECTION("Vector addition") {
+        auto val_x_a = GENERATE(as<T>{}, 1.0, 2.0);  // NOLINT
+        auto val_y_a = GENERATE(as<T>{}, 2.0, 4.0);  // NOLINT
+
+        auto val_x_b = GENERATE(as<T>{}, 0.5, 0.25);  // NOLINT
+        auto val_y_b = GENERATE(as<T>{}, 1.0, 1.25);  // NOLINT
+
+        Vector2 v_a(val_x_a, val_y_a);
+        Vector2 v_b(val_x_b, val_y_b);
+        auto v_result = v_a + v_b;
+
+        REQUIRE(std::abs(v_result.x() - (val_x_a + val_x_b)) < EPSILON);
+        REQUIRE(std::abs(v_result.y() - (val_y_a + val_y_b)) < EPSILON);
+
+        SECTION("Vector substraction") {
+            auto val_x_a = GENERATE(as<T>{}, 1.0, 2.0);  // NOLINT
+            auto val_y_a = GENERATE(as<T>{}, 2.0, 4.0);  // NOLINT
+
+            auto val_x_b = GENERATE(as<T>{}, 0.5, 0.25);  // NOLINT
+            auto val_y_b = GENERATE(as<T>{}, 1.0, 1.25);  // NOLINT
+
+            Vector2 v_a(val_x_a, val_y_a);
+            Vector2 v_b(val_x_b, val_y_b);
+            auto v_result = v_a - v_b;
+
+            REQUIRE(std::abs(v_result.x() - (val_x_a - val_x_b)) < EPSILON);
+            REQUIRE(std::abs(v_result.y() - (val_y_a - val_y_b)) < EPSILON);
+        }
+
+        SECTION("Vector element-wise product") {
+            auto val_x_a = GENERATE(as<T>{}, 1.0, 2.0);  // NOLINT
+            auto val_y_a = GENERATE(as<T>{}, 2.0, 4.0);  // NOLINT
+
+            auto val_x_b = GENERATE(as<T>{}, 0.5, 0.25);  // NOLINT
+            auto val_y_b = GENERATE(as<T>{}, 1.0, 1.25);  // NOLINT
+
+            Vector2 v_a(val_x_a, val_y_a);
+            Vector2 v_b(val_x_b, val_y_b);
+            auto v_result = v_a * v_b;
+
+            REQUIRE(std::abs(v_result.x() - (val_x_a * val_x_b)) < EPSILON);
+            REQUIRE(std::abs(v_result.y() - (val_y_a * val_y_b)) < EPSILON);
+        }
+
+        SECTION("Vector scale (by single scalar)") {
+            auto val_x = GENERATE(as<T>{}, 1.0, 2.0, 3.0, 4.0);     // NOLINT
+            auto val_y = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);     // NOLINT
+            auto scale = GENERATE(as<T>{}, 0.25, 0.50, 0.75, 1.0);  // NOLINT
+
+            Vector2 v(val_x, val_y);
+            auto v_1 = scale * v;
+            auto v_2 = v * scale;
+
+            REQUIRE(std::abs(v_1.x() - (val_x * scale)) < EPSILON);
+            REQUIRE(std::abs(v_1.y() - (val_y * scale)) < EPSILON);
+
+            REQUIRE(std::abs(v_2.x() - (val_x * scale)) < EPSILON);
+            REQUIRE(std::abs(v_2.y() - (val_y * scale)) < EPSILON);
+        }
+
+        SECTION("Vector length") {
+            auto val_x = GENERATE(as<T>{}, 1.0, 2.0, 3.0, 4.0);  // NOLINT
+            auto val_y = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);  // NOLINT
+            Vector2 v(val_x, val_y);
+
+            auto length_square = val_x * val_x + val_y * val_y;
+            auto length = std::sqrt(length_square);
+
+            auto v_length_square = tiny::math::squareNorm(v);
+            auto v_length = tiny::math::norm(v);
+
+            REQUIRE(std::abs(v_length_square - length_square) < EPSILON);
+            REQUIRE(std::abs(v_length - length) < EPSILON);
+        }
+
+        SECTION("Vector normalization (in place)") {
+            auto val_x = GENERATE(as<T>{}, 1.0, 2.0, 3.0, 4.0);  // NOLINT
+            auto val_y = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);  // NOLINT
+            Vector2 v(val_x, val_y);
+            tiny::math::normalize_in_place(v);
+
+            auto norm = std::sqrt(val_x * val_x + val_y * val_y);
+            auto val_xnorm = val_x / norm;
+            auto val_ynorm = val_y / norm;
+
+            auto v_norm = tiny::math::norm(v);
+
+            REQUIRE(std::abs(v_norm - 1.0) < EPSILON);
+            REQUIRE(std::abs(v.x() - val_xnorm) < EPSILON);
+            REQUIRE(std::abs(v.y() - val_ynorm) < EPSILON);
+        }
+
+        SECTION("Vector normalization (out-of place)") {
+            auto val_x = GENERATE(as<T>{}, 1.0, 2.0, 3.0, 4.0);  // NOLINT
+            auto val_y = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);  // NOLINT
+            Vector2 v(val_x, val_y);
+            auto vn = tiny::math::normalize(v);
+
+            auto norm = std::sqrt(val_x * val_x + val_y * val_y);
+            auto val_xnorm = val_x / norm;
+            auto val_ynorm = val_y / norm;
+
+            auto vn_norm = tiny::math::norm(vn);
+
+            REQUIRE(std::abs(vn_norm - 1.0) < EPSILON);
+            REQUIRE(std::abs(vn.x() - val_xnorm) < EPSILON);
+            REQUIRE(std::abs(vn.y() - val_ynorm) < EPSILON);
+        }
+
+        SECTION("Vector dot-product") {
+            auto val_x_a = GENERATE(as<T>{}, 1.0, 2.0, 3.0, 4.0);  // NOLINT
+            auto val_y_a = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);  // NOLINT
+
+            auto val_x_b = GENERATE(as<T>{}, 1.0, 2.0, 3.0, 4.0);  // NOLINT
+            auto val_y_b = GENERATE(as<T>{}, 2.0, 4.0, 6.0, 8.0);  // NOLINT
+
+            Vector2 v_a(val_x_a, val_y_a);
+            Vector2 v_b(val_x_b, val_y_b);
+
+            auto dot = val_x_a * val_x_b + val_y_a * val_y_b;
+            auto v_dot = tiny::math::dot(v_a, v_b);
+
+            REQUIRE(std::abs(v_dot - dot) < EPSILON);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Adds kernel implementations for both `scalar` and `simd(sse)` versions, in the context of vec2-types. Notice we're using `sse` over `avx` even when we have the later, as there's little data to work with for the `YMM` registers to be useful (at least I still haven't found how to benefit from `YMM`s using `vec2`s of either `f32` and `f64`)