### PR TITLE
Integrates `loco_cmake` repo instead of duplicated cmake scripts

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022,windows-2019]
+        os: [windows-latest]
         build-type: [Release, Debug]
 
     name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • MSVC"
@@ -25,17 +25,9 @@ jobs:
       uses: jwlawson/actions-setup-cmake@v1.10
 
     - name: Configure CMake
-      steps:
-        - name: Using Visual Studio 17 2022 on ${{matrix.os}}
-          if: ${{ matrix.os == 'windows-2022' }}
-          env:
-            CMAKE_GENERATOR: "Visual Studio 17 2022"
-          run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
-        - name: Using Visual Studio 16 2019
-          if: ${{ matrix.os == 'windows-2019' }}
-          env:
-            CMAKE_GENERATOR: "Visual Studio 16 2019"
-          run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+      env:
+        CMAKE_GENERATOR: "Visual Studio 17 2022"
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
 
     - name: Build C++ Project
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os: [windows-2022,windows-2019]
         build-type: [Release, Debug]
 
     name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • MSVC"
@@ -25,9 +25,17 @@ jobs:
       uses: jwlawson/actions-setup-cmake@v1.10
 
     - name: Configure CMake
-      env:
-        CMAKE_GENERATOR: "Visual Studio 17 2022"
-      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+      steps:
+        - name: Using Visual Studio 17 2022 on ${{matrix.os}}
+          if: ${{ matrix.os == 'windows-2022' }}
+          env:
+            CMAKE_GENERATOR: "Visual Studio 17 2022"
+          run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+        - name: Using Visual Studio 16 2019
+          if: ${{ matrix.os == 'windows-2019' }}
+          env:
+            CMAKE_GENERATOR: "Visual Studio 16 2019"
+          run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
 
     - name: Build C++ Project
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ project(
 
 # -------------------------------------
 # Define some options the user can set before|while configuring the project
-option(TINYMATH_BUILD_SSE "Build using SSE SIMD-extensions support" OFF)
-option(TINYMATH_BUILD_AVX "Build using AVX SIMD-extensions support" OFF)
+option(TINYMATH_BUILD_SSE "Build using SSE SIMD-extensions support" ON)
+option(TINYMATH_BUILD_AVX "Build using AVX SIMD-extensions support" ON)
 option(TINYMATH_BUILD_INLINE "Build with inlining when requested" OFF)
 option(TINYMATH_BUILD_PYTHON_BINDINGS "Build bindings (requires Pybind11)" ON)
 option(TINYMATH_BUILD_DOCS "Build documentation (requires Doxygen+Breathe)" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,28 @@
-cmake_minimum_required(VERSION 3.15..3.19)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
+# -------------------------------------
+# Get loco_cmake to help us configure our CMake based project
+include(FetchContent)
+FetchContent_Declare(
+  loco_cmake
+  GIT_REPOSITORY https://github.com/wpumacay/loco_cmake.git
+  GIT_TAG main
+  GIT_PROGRESS TRUE
+  GIT_SHALLOW TRUE)
+FetchContent_MakeAvailable(loco_cmake)
+include(${loco_cmake_SOURCE_DIR}/Index.cmake)
+
+# -------------------------------------
+# Define our project :)
 project(
   TinyMath
-  VERSION 0.2.0
+  VERSION 0.3.0
   DESCRIPTION "A basic math library for vectors and matrices"
   HOMEPAGE_URL "https://github.com/wpumacay/tiny_math"
   LANGUAGES C CXX)
 
-# Include some helper functions that we will need later
-include(${PROJECT_SOURCE_DIR}/cmake/Common.cmake)
-include(${PROJECT_SOURCE_DIR}/cmake/Utils.cmake)
-
-# Include some internal tools we might need to use
-include(FetchContent)
-include(GNUInstallDirs)
-
-# Check if we're currently working as the root project. If so, configure some
-# common settings that we might need later during configuration
-tmInitializeProject()
-
+# -------------------------------------
+# Define some options the user can set before|while configuring the project
 option(TINYMATH_BUILD_SSE "Build using SSE SIMD-extensions support" OFF)
 option(TINYMATH_BUILD_AVX "Build using AVX SIMD-extensions support" OFF)
 option(TINYMATH_BUILD_INLINE "Build with inlining when requested" OFF)
@@ -27,39 +31,84 @@ option(TINYMATH_BUILD_DOCS "Build documentation (requires Doxygen+Breathe)" OFF)
 option(TINYMATH_BUILD_TESTS "Build C++ unit-tests (requires google-test)" ON)
 option(TINYMATH_BUILD_EXAMPLES "Build C++ examples" ON)
 
-add_library(TinyMathCpp INTERFACE)
-# Set features and other settings for this target
-target_compile_features(TinyMathCpp INTERFACE cxx_std_11)
-target_include_directories(TinyMathCpp
-                           INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+# -------------------------------------
+# Initialize the project using our helper modules :D
+loco_initialize_project()
 
-# Configure the target with the required compiler features and options
+# -------------------------------------
+# Get the required third-party dependencies
+add_subdirectory(third_party)
+
 # cmake-format: off
-tmSetupCompileProperties(
-  PROJECT TinyMath
-  TARGET TinyMathCpp
-  USE_SSE ${TINYMATH_BUILD_SSE}
-  USE_AVX ${TINYMATH_BUILD_AVX}
-  USE_INLINE ${TINYMATH_BUILD_INLINE})
+# -------------------------------------
+# Setup the main C++ target `TinyMathCpp`
+add_library(TinyMathCpp INTERFACE)
+loco_setup_target(
+  TinyMathCpp
+  SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/common.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/vec2_t.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/vec2_t_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/vec3_t.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/vec3_t_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/vec4_t.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/vec4_t_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/mat4_t.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/mat4_t_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/vec2_t_scalar_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/vec2_t_sse_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/vec3_t_scalar_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/vec3_t_sse_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/vec3_t_avx_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/vec4_t_scalar_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/vec4_t_sse_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/vec4_t_avx_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/mat4_t_scalar_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/mat4_t_sse_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/impl/mat4_t_avx_impl.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/tinymath/tinymath.hpp
+  INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  WARNINGS_AS_ERRORS
+    FALSE
+  ENABLE_SSE
+    ${TINYMATH_BUILD_SSE}
+  ENABLE_AVX
+    ${TINYMATH_BUILD_AVX}
+)
 # cmake-format: on
 
+# -------------------------------------
+# If force-inline is being requested, then add it to the target
+if(TINYMATH_BUILD_INLINE)
+  # @todo(wilbert): Move this to one of the setup helpers on the loco-cmake repo
+  target_compile_definitions(TinyMathCpp PUBLIC -DTINYMATH_FORCE_INLINE)
+endif()
+
+# -------------------------------------
 # Expose an alias for the library (CMake namespace convention)
 add_library(tinymath::tinymath ALIAS TinyMathCpp)
 
-# Add dependencies to the build process
-add_subdirectory(third_party)
-
+# -------------------------------------
 # Add C++ examples to the build process
 add_subdirectory(examples/cpp)
 
+# -------------------------------------
 # Add C++ tests to the build process
 add_subdirectory(tests/cpp)
 
+# -------------------------------------
 # Add Python bindings to the build process
 add_subdirectory(python/tinymath/bindings)
 
-# ~~~
-# add_subdirectory(docs)
-# ~~~
+# -------------------------------------
+# Show the properties of our main target
+loco_print_target_properties(TinyMathCpp)
 
-tmPrintSummary(TARGET TinyMathCpp)
+# -------------------------------------
+# Show some info of the this project
+loco_print_project_info()
+
+# -------------------------------------
+# Show some info of the host
+loco_print_host_info()

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -7,7 +7,8 @@ if(NOT TINYMATH_BUILD_EXAMPLES)
 endif()
 
 if(NOT TARGET tinymath::tinymath)
-  tmMessage("Examples require tinymath::tinymath target" LOG_LEVEL WARNING)
+  loco_message("Examples require the [tinymath::tinymath] target to be defined"
+               LOG_LEVEL WARNING)
   return()
 endif()
 
@@ -24,7 +25,10 @@ set(TINYMATH_EXAMPLES_LIST
     # Examples used to check each op assembly listing
     ${CMAKE_CURRENT_SOURCE_DIR}/operations/ex_vec3f_ops.cpp)
 
-# Create all the example targets
-foreach(example_filepath IN LISTS TINYMATH_EXAMPLES_LIST)
-  tmConfigureExample(${example_filepath})
-endforeach()
+# ~~~
+# @todo(wilbert): complete this part (add helper macro to loco-cmake)
+# # Create all the example targets
+# foreach(example_filepath IN LISTS TINYMATH_EXAMPLES_LIST)
+#   loco_setup_singlefile_example(${example_filepath})
+# endforeach()
+# ~~~

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -25,10 +25,8 @@ set(TINYMATH_EXAMPLES_LIST
     # Examples used to check each op assembly listing
     ${CMAKE_CURRENT_SOURCE_DIR}/operations/ex_vec3f_ops.cpp)
 
-# ~~~
-# @todo(wilbert): complete this part (add helper macro to loco-cmake)
-# # Create all the example targets
-# foreach(example_filepath IN LISTS TINYMATH_EXAMPLES_LIST)
-#   loco_setup_singlefile_example(${example_filepath})
-# endforeach()
-# ~~~
+# Create all the example targets
+foreach(example_filepath IN LISTS TINYMATH_EXAMPLES_LIST)
+  loco_setup_single_file_example(${example_filepath} TARGET_DEPENDENCIES
+                                 tinymath::tinymath)
+endforeach()

--- a/include/tinymath/impl/mat4_t_avx_impl.hpp
+++ b/include/tinymath/impl/mat4_t_avx_impl.hpp
@@ -46,44 +46,6 @@ template <typename T>
 using Vec4Buffer = typename Vector4<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_MAT4_F32_AVX() -> int {
-    constexpr uint32_t EXPECTED_BUFFER_SIZE = 16;
-    constexpr uint32_t EXPECTED_NUM_DIMENSIONS = 4;
-    constexpr uint32_t EXPECTED_SIZEOF = sizeof(float) * EXPECTED_BUFFER_SIZE;
-
-    static_assert(std::is_same<float, T>::value,
-                  "4x4 f32 matrices should use single-precision floats");
-    static_assert(Matrix4<T>::BUFFER_SIZE == EXPECTED_BUFFER_SIZE,
-                  "4x4 matrices must use 16 elements for the internal buffer");
-    static_assert(Matrix4<T>::MATRIX_NDIM == EXPECTED_NUM_DIMENSIONS,
-                  "4x4 matrices must have 4 as number of dimensions");
-    static_assert(sizeof(Matrix4<T>) == EXPECTED_SIZEOF,
-                  "4x4 matrices must use exactly this many bytes of storage");
-    static_assert(alignof(Matrix4<T>) == EXPECTED_SIZEOF,
-                  "4x4 matrices must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_MAT4_F64_AVX() -> int {
-    constexpr uint32_t EXPECTED_BUFFER_SIZE = 16;
-    constexpr uint32_t EXPECTED_NUM_DIMENSIONS = 4;
-    constexpr uint32_t EXPECTED_SIZEOF = sizeof(double) * EXPECTED_BUFFER_SIZE;
-
-    static_assert(std::is_same<double, T>::value,
-                  "4x4 f32 matrices should use single-precision floats");
-    static_assert(Matrix4<T>::BUFFER_SIZE == EXPECTED_BUFFER_SIZE,
-                  "4x4 matrices must use 16 elements for the internal buffer");
-    static_assert(Matrix4<T>::MATRIX_NDIM == EXPECTED_NUM_DIMENSIONS,
-                  "4x4 matrices must have 4 as number of dimensions");
-    static_assert(sizeof(Matrix4<T>) == EXPECTED_SIZEOF,
-                  "4x4 matrices must use exactly this many bytes of storage");
-    static_assert(alignof(Matrix4<T>) == EXPECTED_SIZEOF,
-                  "4x4 matrices must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_MAT4_F32_AVX_GUARD =
     typename std::enable_if<CpuHasAVX<T>::value && IsFloat32<T>::value>::type*;
 

--- a/include/tinymath/impl/mat4_t_scalar_impl.hpp
+++ b/include/tinymath/impl/mat4_t_scalar_impl.hpp
@@ -15,28 +15,11 @@ template <typename T>
 using Vec4Buffer = typename Vector4<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_MAT4_SCALAR() -> int {
-    constexpr uint32_t EXPECTED_BUFFER_SIZE = 16;
-    constexpr uint32_t EXPECTED_NUM_DIMENSIONS = 4;
-
-    static_assert(Matrix4<T>::BUFFER_SIZE == EXPECTED_BUFFER_SIZE,
-                  "4x4 matrices must use 16 elements for the internal buffer");
-    static_assert(Matrix4<T>::MATRIX_NDIM == EXPECTED_NUM_DIMENSIONS,
-                  "4x4 matrices must have 4 as number of dimensions");
-    static_assert(sizeof(Matrix4<T>) == sizeof(T) * EXPECTED_BUFFER_SIZE,
-                  "4x4 matrices must use exactly this many bytes of storage");
-    static_assert(alignof(Matrix4<T>) == sizeof(T) * EXPECTED_BUFFER_SIZE,
-                  "4x4 matrices must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_MAT4_SCALAR_GUARD =
     typename std::enable_if<IsScalar<T>::value>::type*;
 
 template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_transpose_inplace_mat4(Mat4Buffer<T>& cols) -> void {
-    COMPILE_TIME_CHECKS_MAT4_SCALAR<T>();
     for (int32_t col = 1; col < Matrix4<T>::MATRIX_NDIM; ++col) {
         for (int32_t row = 0; row < Matrix4<T>::MATRIX_NDIM; ++row) {
             std::swap(cols[col][row], cols[row][col]);
@@ -47,7 +30,6 @@ TM_INLINE auto kernel_transpose_inplace_mat4(Mat4Buffer<T>& cols) -> void {
 template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
                                const Mat4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_MAT4_SCALAR<T>();
     for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
         for (int32_t idx = 0; idx < Matrix4<T>::MATRIX_NDIM; ++idx) {
             dst[col][idx] = lhs[col][idx] + rhs[col][idx];
@@ -58,7 +40,6 @@ TM_INLINE auto kernel_add_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
 template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
                                const Mat4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_MAT4_SCALAR<T>();
     for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
         for (int32_t idx = 0; idx < Matrix4<T>::MATRIX_NDIM; ++idx) {
             dst[col][idx] = lhs[col][idx] - rhs[col][idx];
@@ -69,7 +50,6 @@ TM_INLINE auto kernel_sub_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
 template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_mat4(Mat4Buffer<T>& dst, T scale,
                                  const Mat4Buffer<T>& mat) -> void {
-    COMPILE_TIME_CHECKS_MAT4_SCALAR<T>();
     for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
         for (int32_t idx = 0; idx < Matrix4<T>::MATRIX_NDIM; ++idx) {
             dst[col][idx] = scale * mat[col][idx];
@@ -80,7 +60,6 @@ TM_INLINE auto kernel_scale_mat4(Mat4Buffer<T>& dst, T scale,
 template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_matmul_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
                                   const Mat4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_MAT4_SCALAR<T>();
     // We're assumming that dst is zero-initialized (default-constructor)
     for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
         for (int32_t row = 0; row < Matrix4<T>::MATRIX_NDIM; ++row) {
@@ -94,7 +73,6 @@ TM_INLINE auto kernel_matmul_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
 template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_matmul_vec_mat4(const Mat4Buffer<T>& mat,
                                       const Vec4Buffer<T>& vec) -> Vector4<T> {
-    COMPILE_TIME_CHECKS_MAT4_SCALAR<T>();
     // Express as a linear combination of the columns of the matrix
     return vec[0] * mat[0] + vec[1] * mat[1] + vec[2] * mat[2] +
            vec[3] * mat[3];
@@ -104,7 +82,6 @@ template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_mat4(Mat4Buffer<T>& dst,
                                     const Mat4Buffer<T>& lhs,
                                     const Mat4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_MAT4_SCALAR<T>();
     for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
         for (int32_t idx = 0; idx < Matrix4<T>::MATRIX_NDIM; ++idx) {
             dst[col][idx] = lhs[col][idx] * rhs[col][idx];
@@ -115,7 +92,6 @@ TM_INLINE auto kernel_hadamard_mat4(Mat4Buffer<T>& dst,
 template <typename T, SFINAE_MAT4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_compare_eq_mat4(const Mat4Buffer<T>& lhs,
                                       const Mat4Buffer<T>& rhs) -> bool {
-    COMPILE_TIME_CHECKS_MAT4_SCALAR<T>();
     for (int32_t col = 0; col < Matrix4<T>::MATRIX_NDIM; ++col) {
         for (int32_t idx = 0; idx < Matrix4<T>::MATRIX_NDIM; ++idx) {
             if (std::abs(lhs[col][idx] - rhs[col][idx]) > tiny::math::EPS<T>) {

--- a/include/tinymath/impl/mat4_t_sse_impl.hpp
+++ b/include/tinymath/impl/mat4_t_sse_impl.hpp
@@ -48,44 +48,6 @@ template <typename T>
 using Vec4Buffer = typename Vector4<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_MAT4_F32_SSE() -> int {
-    constexpr uint32_t EXPECTED_BUFFER_SIZE = 16;
-    constexpr uint32_t EXPECTED_NUM_DIMENSIONS = 4;
-    constexpr uint32_t EXPECTED_SIZEOF = sizeof(float) * EXPECTED_BUFFER_SIZE;
-
-    static_assert(std::is_same<float, T>::value,
-                  "4x4 f32 matrices should use single-precision floats");
-    static_assert(Matrix4<T>::BUFFER_SIZE == EXPECTED_BUFFER_SIZE,
-                  "4x4 matrices must use 16 elements for the internal buffer");
-    static_assert(Matrix4<T>::MATRIX_NDIM == EXPECTED_NUM_DIMENSIONS,
-                  "4x4 matrices must have 4 as number of dimensions");
-    static_assert(sizeof(Matrix4<T>) == EXPECTED_SIZEOF,
-                  "4x4 matrices must use exactly this many bytes of storage");
-    static_assert(alignof(Matrix4<T>) == EXPECTED_SIZEOF,
-                  "4x4 matrices must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_MAT4_F64_SSE() -> int {
-    constexpr uint32_t EXPECTED_BUFFER_SIZE = 16;
-    constexpr uint32_t EXPECTED_NUM_DIMENSIONS = 4;
-    constexpr uint32_t EXPECTED_SIZEOF = sizeof(double) * EXPECTED_BUFFER_SIZE;
-
-    static_assert(std::is_same<double, T>::value,
-                  "4x4 f32 matrices should use single-precision floats");
-    static_assert(Matrix4<T>::BUFFER_SIZE == EXPECTED_BUFFER_SIZE,
-                  "4x4 matrices must use 16 elements for the internal buffer");
-    static_assert(Matrix4<T>::MATRIX_NDIM == EXPECTED_NUM_DIMENSIONS,
-                  "4x4 matrices must have 4 as number of dimensions");
-    static_assert(sizeof(Matrix4<T>) == EXPECTED_SIZEOF,
-                  "4x4 matrices must use exactly this many bytes of storage");
-    static_assert(alignof(Matrix4<T>) == EXPECTED_SIZEOF,
-                  "4x4 matrices must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_MAT4_F32_SSE_GUARD =
     typename std::enable_if<CpuHasSSE<T>::value && IsFloat32<T>::value>::type*;
 
@@ -100,7 +62,6 @@ using SFINAE_MAT4_F64_SSE_GUARD =
 template <typename T, SFINAE_MAT4_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_mat4(Mat4Buffer<T>& dst, const Mat4Buffer<T>& lhs,
                                const Mat4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_MAT4_F32_SSE<T>();
     // [c0, c1, c2, c3] -> column-major order (in storage), each with 4 x f32
     // So, we can send each column to an xmm register. Also, don't unroll the
     // loop, as it most likely be optimized by the compiler and unroll it for us

--- a/include/tinymath/impl/vec2_t_scalar_impl.hpp
+++ b/include/tinymath/impl/vec2_t_scalar_impl.hpp
@@ -11,28 +11,12 @@ template <typename T>
 using Vec2Buffer = typename Vector2<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC2_SCALAR() -> int {
-    static_assert(Vector2<T>::BUFFER_SIZE == 2,
-                  "Must use 2 elements for the internal buffer");
-    static_assert(Vector2<T>::VECTOR_NDIM == 2,
-                  "Must use 2 elements for the vector elements");
-    static_assert(
-        sizeof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_VEC2_SCALAR_GUARD =
     typename std::enable_if<IsScalar<T>::value>::type*;
 
 template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
                                const Vec2Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
     for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] + rhs[i];
     }
@@ -41,7 +25,6 @@ TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
 template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
                                const Vec2Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
     for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] - rhs[i];
     }
@@ -50,7 +33,6 @@ TM_INLINE auto kernel_sub_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
 template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec2(Vec2Buffer<T>& dst, T scale,
                                  const Vec2Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
     for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
         dst[i] = scale * vec[i];
     }
@@ -60,7 +42,6 @@ template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec2(Vec2Buffer<T>& dst,
                                     const Vec2Buffer<T>& lhs,
                                     const Vec2Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
     for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] * rhs[i];
     }
@@ -68,7 +49,6 @@ TM_INLINE auto kernel_hadamard_vec2(Vec2Buffer<T>& dst,
 
 template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec2(const Vec2Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
     T accum = static_cast<T>(0.0);
     for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
         accum += vec[i] * vec[i];
@@ -78,7 +58,6 @@ TM_INLINE auto kernel_length_square_vec2(const Vec2Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec2(Vec2Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
     auto length = std::sqrt(kernel_length_square_vec2<T>(vec));
     for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
         vec[i] /= length;
@@ -88,7 +67,6 @@ TM_INLINE auto kernel_normalize_in_place_vec2(Vec2Buffer<T>& vec) -> void {
 template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec2(const Vec2Buffer<T>& lhs,
                                const Vec2Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
     T accum = static_cast<T>(0.0);
     for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
         accum += lhs[i] * rhs[i];
@@ -99,7 +77,6 @@ TM_INLINE auto kernel_dot_vec2(const Vec2Buffer<T>& lhs,
 template <typename T, SFINAE_VEC2_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_compare_eq_vec2(const Vec2Buffer<T>& lhs,
                                       const Vec2Buffer<T>& rhs) -> bool {
-    COMPILE_TIME_CHECKS_VEC2_SCALAR<T>();
     for (int32_t i = 0; i < Vector2<T>::VECTOR_NDIM; ++i) {
         if (std::abs(lhs[i] - rhs[i]) >= tiny::math::EPS<T>) {
             return false;

--- a/include/tinymath/impl/vec2_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec2_t_sse_impl.hpp
@@ -45,38 +45,6 @@ template <typename T>
 using Vec2Buffer = typename Vector2<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC2_F32_SSE() -> int {
-    static_assert(std::is_same<float, T>::value, "Must be using f32");
-    static_assert(Vector2<T>::BUFFER_SIZE == 2,
-                  "Must be using 2xf32 as aligned buffer");
-    static_assert(Vector2<T>::VECTOR_NDIM == 2,
-                  "Must be using 2xf32 for the elements of the vector");
-    static_assert(
-        sizeof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC2_F64_SSE() -> int {
-    static_assert(std::is_same<double, T>::value, "Must be using f64");
-    static_assert(Vector2<T>::BUFFER_SIZE == 2,
-                  "Must be using 2xf64 as aligned buffer");
-    static_assert(Vector2<T>::VECTOR_NDIM == 2,
-                  "Must be using 2xf64 for the elements of the vector");
-    static_assert(
-        sizeof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector2<T>) == sizeof(std::array<T, Vector2<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_VEC2_F32_SSE_GUARD =
     typename std::enable_if<(CpuHasSSE<T>::value || CpuHasAVX<T>::value) &&
                             IsFloat32<T>::value>::type*;
@@ -89,7 +57,6 @@ using SFINAE_VEC2_F64_SSE_GUARD =
 template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
                                const Vec2Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
     auto xmm_lhs = _mm_loadu_ps(lhs.data());
     auto xmm_rhs = _mm_loadu_ps(rhs.data());
     auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
@@ -99,7 +66,6 @@ TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
 template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
                                const Vec2Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
     auto xmm_lhs = _mm_loadu_pd(lhs.data());
     auto xmm_rhs = _mm_loadu_pd(rhs.data());
     auto xmm_result = _mm_add_pd(xmm_lhs, xmm_rhs);
@@ -109,7 +75,6 @@ TM_INLINE auto kernel_add_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
 template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
                                const Vec2Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
     auto xmm_lhs = _mm_loadu_ps(lhs.data());
     auto xmm_rhs = _mm_loadu_ps(rhs.data());
     auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
@@ -119,7 +84,6 @@ TM_INLINE auto kernel_sub_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
 template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
                                const Vec2Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
     auto xmm_lhs = _mm_loadu_pd(lhs.data());
     auto xmm_rhs = _mm_loadu_pd(rhs.data());
     auto xmm_result = _mm_sub_pd(xmm_lhs, xmm_rhs);
@@ -129,7 +93,6 @@ TM_INLINE auto kernel_sub_vec2(Vec2Buffer<T>& dst, const Vec2Buffer<T>& lhs,
 template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec2(Vec2Buffer<T>& dst, T scale,
                                  const Vec2Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
     auto xmm_scale = _mm_set1_ps(scale);
     auto xmm_vector = _mm_loadu_ps(vec.data());
     auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
@@ -139,7 +102,6 @@ TM_INLINE auto kernel_scale_vec2(Vec2Buffer<T>& dst, T scale,
 template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec2(Vec2Buffer<T>& dst, T scale,
                                  const Vec2Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
     auto xmm_scale = _mm_set1_pd(scale);
     auto xmm_vector = _mm_loadu_pd(vec.data());
     auto xmm_result = _mm_mul_pd(xmm_scale, xmm_vector);
@@ -150,7 +112,6 @@ template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec2(Vec2Buffer<T>& dst,
                                     const Vec2Buffer<T>& lhs,
                                     const Vec2Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
     auto xmm_lhs = _mm_loadu_ps(lhs.data());
     auto xmm_rhs = _mm_loadu_ps(rhs.data());
     auto xmm_result = _mm_mul_ps(xmm_lhs, xmm_rhs);
@@ -161,7 +122,6 @@ template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec2(Vec2Buffer<T>& dst,
                                     const Vec2Buffer<T>& lhs,
                                     const Vec2Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
     auto xmm_lhs = _mm_loadu_pd(lhs.data());
     auto xmm_rhs = _mm_loadu_pd(rhs.data());
     auto xmm_result = _mm_mul_pd(xmm_lhs, xmm_rhs);
@@ -170,7 +130,6 @@ TM_INLINE auto kernel_hadamard_vec2(Vec2Buffer<T>& dst,
 
 template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec2(const Vec2Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_loadu_ps(vec.data());
     auto xmm_square_sum = _mm_dp_ps(xmm_v, xmm_v, 0x31);
@@ -179,7 +138,6 @@ TM_INLINE auto kernel_length_square_vec2(const Vec2Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec2(const Vec2Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_loadu_pd(vec.data());
     auto xmm_square_sum = _mm_dp_pd(xmm_v, xmm_v, 0x31);
@@ -188,7 +146,6 @@ TM_INLINE auto kernel_length_square_vec2(const Vec2Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_vec2(const Vec2Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_loadu_ps(vec.data());
     auto xmm_square_sum = _mm_dp_ps(xmm_v, xmm_v, 0x31);
@@ -197,7 +154,6 @@ TM_INLINE auto kernel_length_vec2(const Vec2Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_vec2(const Vec2Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_loadu_pd(vec.data());
     auto xmm_square_sum = _mm_dp_pd(xmm_v, xmm_v, 0x31);
@@ -206,7 +162,6 @@ TM_INLINE auto kernel_length_vec2(const Vec2Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec2(Vec2Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_loadu_ps(vec.data());
     auto xmm_sums = _mm_dp_ps(xmm_v, xmm_v, 0x3f);
@@ -217,7 +172,6 @@ TM_INLINE auto kernel_normalize_in_place_vec2(Vec2Buffer<T>& vec) -> void {
 
 template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec2(Vec2Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_loadu_pd(vec.data());
     auto xmm_sums = _mm_dp_pd(xmm_v, xmm_v, 0x33);
@@ -229,7 +183,6 @@ TM_INLINE auto kernel_normalize_in_place_vec2(Vec2Buffer<T>& vec) -> void {
 template <typename T, SFINAE_VEC2_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec2(const Vec2Buffer<T>& lhs,
                                const Vec2Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC2_F32_SSE<T>();
     auto xmm_lhs = _mm_loadu_ps(lhs.data());
     auto xmm_rhs = _mm_loadu_ps(rhs.data());
     auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0x31);
@@ -239,7 +192,6 @@ TM_INLINE auto kernel_dot_vec2(const Vec2Buffer<T>& lhs,
 template <typename T, SFINAE_VEC2_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec2(const Vec2Buffer<T>& lhs,
                                const Vec2Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC2_F64_SSE<T>();
     auto xmm_lhs = _mm_loadu_pd(lhs.data());
     auto xmm_rhs = _mm_loadu_pd(rhs.data());
     auto xmm_dot = _mm_dp_pd(xmm_lhs, xmm_rhs, 0x31);

--- a/include/tinymath/impl/vec3_t_avx_impl.hpp
+++ b/include/tinymath/impl/vec3_t_avx_impl.hpp
@@ -35,38 +35,6 @@ template <typename T>
 using Vec3Buffer = typename Vector3<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC3_F32_AVX() -> int {
-    static_assert(std::is_same<float, T>::value, "Must be using f32");
-    static_assert(Vector3<T>::BUFFER_SIZE == 4,
-                  "Must be using 4xf32 as aligned buffer");
-    static_assert(Vector3<T>::VECTOR_NDIM == 3,
-                  "Must be using 3xf32 for the elements of the vector");
-    static_assert(
-        sizeof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC3_F64_AVX() -> int {
-    static_assert(std::is_same<double, T>::value, "Must be using f64");
-    static_assert(Vector3<T>::BUFFER_SIZE == 4,
-                  "Must be using 4xf64 as aligned buffer");
-    static_assert(Vector3<T>::VECTOR_NDIM == 3,
-                  "Must be using 3xf64 for the elements of the vector");
-    static_assert(
-        sizeof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_VEC3_F32_AVX_GUARD =
     typename std::enable_if<CpuHasAVX<T>::value && IsFloat32<T>::value>::type*;
 
@@ -77,7 +45,6 @@ using SFINAE_VEC3_F64_AVX_GUARD =
 template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
@@ -87,7 +54,6 @@ TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_AVX<T>();
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_add_pd(ymm_lhs, ymm_rhs);
@@ -97,7 +63,6 @@ TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
@@ -107,7 +72,6 @@ TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_AVX<T>();
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_sub_pd(ymm_lhs, ymm_rhs);
@@ -117,7 +81,6 @@ TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec3(Vec3Buffer<T>& dst, T scale,
                                  const Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     auto xmm_scale = _mm_set1_ps(scale);
     auto xmm_vector = _mm_load_ps(vec.data());
     auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
@@ -127,7 +90,6 @@ TM_INLINE auto kernel_scale_vec3(Vec3Buffer<T>& dst, T scale,
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec3(Vec3Buffer<T>& dst, T scale,
                                  const Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_AVX<T>();
     auto ymm_scale = _mm256_set1_pd(scale);
     auto ymm_vector = _mm256_load_pd(vec.data());
     auto ymm_result = _mm256_mul_pd(ymm_scale, ymm_vector);
@@ -138,7 +100,6 @@ template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec3(Vec3Buffer<T>& dst,
                                     const Vec3Buffer<T>& lhs,
                                     const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     _mm_store_ps(dst.data(), _mm_mul_ps(xmm_lhs, xmm_rhs));
@@ -148,7 +109,6 @@ template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec3(Vec3Buffer<T>& dst,
                                     const Vec3Buffer<T>& lhs,
                                     const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_AVX<T>();
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     _mm256_store_pd(dst.data(), _mm256_mul_pd(ymm_lhs, ymm_rhs));
@@ -156,7 +116,6 @@ TM_INLINE auto kernel_hadamard_vec3(Vec3Buffer<T>& dst,
 
 template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_load_ps(vec.data());
     return _mm_cvtss_f32(_mm_dp_ps(xmm_v, xmm_v, 0x71));
@@ -164,7 +123,6 @@ TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F64_AVX<T>();
     // Implementation based on this post: https://bit.ly/3lt3ts4
     // Instruction-sets required (AVX, SSE2)
     // -------------------------
@@ -181,7 +139,6 @@ TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_load_ps(vec.data());
     return _mm_cvtss_f32(_mm_sqrt_ss(_mm_dp_ps(xmm_v, xmm_v, 0x71)));
@@ -189,7 +146,6 @@ TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F64_AVX<T>();
     // Implementation based on this post: https://bit.ly/3lt3ts4
     // Instruction-sets required (AVX, SSE2)
     // -------------------------
@@ -206,7 +162,6 @@ TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_load_ps(vec.data());
     auto xmm_sums = _mm_dp_ps(xmm_v, xmm_v, 0x7f);
@@ -217,7 +172,6 @@ TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
 
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_AVX<T>();
     auto ymm_v = _mm256_load_pd(vec.data());
     auto ymm_prod = _mm256_mul_pd(ymm_v, ymm_v);
     // Construct the sum of squares into each double of a 256-bit register
@@ -234,7 +188,6 @@ TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
 template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0x71);
@@ -244,7 +197,6 @@ TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F64_AVX<T>();
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_prod = _mm256_mul_pd(ymm_lhs, ymm_rhs);
@@ -258,7 +210,6 @@ TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                  const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_AVX<T>();
     // Implementation adapted from @ian_mallett (https://bit.ly/3lu6pVe)
     // Recall that the dot product of two 3d-vectors a and b given by:
     // a = {a[0], a[1], a[2], a[3]=0}, b = {b[0], b[1], b[2], b[3]=0}
@@ -292,7 +243,6 @@ TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                  const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_AVX<T>();
     // Implementation adapted from @ian_mallett (https://bit.ly/3lu6pVe)
     auto vec_a = _mm256_load_pd(lhs.data());
     auto vec_b = _mm256_load_pd(rhs.data());

--- a/include/tinymath/impl/vec3_t_scalar_impl.hpp
+++ b/include/tinymath/impl/vec3_t_scalar_impl.hpp
@@ -11,28 +11,12 @@ template <typename T>
 using Vec3Buffer = typename Vector3<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC3_SCALAR() -> int {
-    static_assert(Vector3<T>::BUFFER_SIZE == 4,
-                  "Must use 4 elements for the internal buffer");
-    static_assert(Vector3<T>::VECTOR_NDIM == 3,
-                  "Must use 4 elements for the vector elements");
-    static_assert(
-        sizeof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_VEC3_SCALAR_GUARD =
     typename std::enable_if<IsScalar<T>::value>::type*;
 
 template <typename T, SFINAE_VEC3_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_SCALAR<T>();
     for (int32_t i = 0; i < Vector3<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] + rhs[i];
     }
@@ -41,7 +25,6 @@ TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_SCALAR<T>();
     for (int32_t i = 0; i < Vector3<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] - rhs[i];
     }
@@ -50,7 +33,6 @@ TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec3(Vec3Buffer<T>& dst, T scale,
                                  const Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_SCALAR<T>();
     for (int32_t i = 0; i < Vector3<T>::VECTOR_NDIM; ++i) {
         dst[i] = scale * vec[i];
     }
@@ -60,7 +42,6 @@ template <typename T, SFINAE_VEC3_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec3(Vec3Buffer<T>& dst,
                                     const Vec3Buffer<T>& lhs,
                                     const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_SCALAR<T>();
     for (int32_t i = 0; i < Vector3<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] * rhs[i];
     }
@@ -68,7 +49,6 @@ TM_INLINE auto kernel_hadamard_vec3(Vec3Buffer<T>& dst,
 
 template <typename T, SFINAE_VEC3_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC3_SCALAR<T>();
     T accum = static_cast<T>(0.0);
     for (int32_t i = 0; i < Vector3<T>::VECTOR_NDIM; ++i) {
         accum += vec[i] * vec[i];
@@ -78,7 +58,6 @@ TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC3_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_SCALAR<T>();
     auto length = std::sqrt(kernel_length_square_vec3<T>(vec));
     for (int32_t i = 0; i < Vector3<T>::VECTOR_NDIM; ++i) {
         vec[i] /= length;
@@ -88,7 +67,6 @@ TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
 template <typename T, SFINAE_VEC3_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC3_SCALAR<T>();
     T accum = static_cast<T>(0.0);
     for (int32_t i = 0; i < Vector3<T>::VECTOR_NDIM; ++i) {
         accum += lhs[i] * rhs[i];
@@ -99,7 +77,6 @@ TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_compare_eq_vec3(const Vec3Buffer<T>& lhs,
                                       const Vec3Buffer<T>& rhs) -> bool {
-    COMPILE_TIME_CHECKS_VEC3_SCALAR<T>();
     for (int32_t i = 0; i < Vector3<T>::VECTOR_NDIM; ++i) {
         if (std::abs(lhs[i] - rhs[i]) >= tiny::math::EPS<T>) {
             return false;
@@ -111,7 +88,6 @@ TM_INLINE auto kernel_compare_eq_vec3(const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                  const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_SCALAR<T>();
     // v.x =  v1.y  *  v2.z  -  v1.z  *  v2.y
     dst[0] = lhs[1] * rhs[2] - lhs[2] * rhs[1];
     // v.y =  v1.z  *  v2.x  -  v1.x  *  v2.z

--- a/include/tinymath/impl/vec3_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec3_t_sse_impl.hpp
@@ -42,38 +42,6 @@ template <typename T>
 using Vec3Buffer = typename Vector3<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC3_F32_SSE() -> int {
-    static_assert(std::is_same<float, T>::value, "Must be using f32");
-    static_assert(Vector3<T>::BUFFER_SIZE == 4,
-                  "Must be using 4xf32 as aligned buffer");
-    static_assert(Vector3<T>::VECTOR_NDIM == 3,
-                  "Must be using 3xf32 for the elements of the vector");
-    static_assert(
-        sizeof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC3_F64_SSE() -> int {
-    static_assert(std::is_same<double, T>::value, "Must be using f64");
-    static_assert(Vector3<T>::BUFFER_SIZE == 4,
-                  "Must be using 4xf64 as aligned buffer");
-    static_assert(Vector3<T>::VECTOR_NDIM == 3,
-                  "Must be using 3xf64 for the elements of the vector");
-    static_assert(
-        sizeof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector3<T>) == sizeof(std::array<T, Vector3<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_VEC3_F32_SSE_GUARD =
     typename std::enable_if<CpuHasSSE<T>::value && IsFloat32<T>::value>::type*;
 
@@ -84,7 +52,6 @@ using SFINAE_VEC3_F64_SSE_GUARD =
 template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
@@ -94,7 +61,6 @@ TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     auto xmm_lhs_lo = _mm_load_pd(lhs.data());
     auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);
     auto xmm_rhs_lo = _mm_load_pd(rhs.data());
@@ -108,7 +74,6 @@ TM_INLINE auto kernel_add_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
@@ -118,7 +83,6 @@ TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     auto xmm_lhs_lo = _mm_load_pd(lhs.data());
     auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);
     auto xmm_rhs_lo = _mm_load_pd(rhs.data());
@@ -132,7 +96,6 @@ TM_INLINE auto kernel_sub_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec3(Vec3Buffer<T>& dst, T scale,
                                  const Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     auto xmm_scale = _mm_set1_ps(scale);
     auto xmm_vector = _mm_load_ps(vec.data());
     auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
@@ -142,7 +105,6 @@ TM_INLINE auto kernel_scale_vec3(Vec3Buffer<T>& dst, T scale,
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec3(Vec3Buffer<T>& dst, T scale,
                                  const Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     auto xmm_scale = _mm_set1_pd(scale);
     auto xmm_vector_lo = _mm_load_pd(vec.data());
     auto xmm_vector_hi = _mm_load_pd(vec.data() + 2);
@@ -156,7 +118,6 @@ template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec3(Vec3Buffer<T>& dst,
                                     const Vec3Buffer<T>& lhs,
                                     const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     _mm_store_ps(dst.data(), _mm_mul_ps(xmm_lhs, xmm_rhs));
@@ -166,7 +127,6 @@ template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec3(Vec3Buffer<T>& dst,
                                     const Vec3Buffer<T>& lhs,
                                     const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     auto xmm_lhs_lo = _mm_load_pd(lhs.data());
     auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);
     auto xmm_rhs_lo = _mm_load_pd(rhs.data());
@@ -177,7 +137,6 @@ TM_INLINE auto kernel_hadamard_vec3(Vec3Buffer<T>& dst,
 
 template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_load_ps(vec.data());
     return _mm_cvtss_f32(_mm_dp_ps(xmm_v, xmm_v, 0x71));
@@ -185,7 +144,6 @@ TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v_lo = _mm_load_pd(vec.data());
     auto xmm_v_hi = _mm_load_pd(vec.data() + 2);
@@ -197,7 +155,6 @@ TM_INLINE auto kernel_length_square_vec3(const Vec3Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_load_ps(vec.data());
     return _mm_cvtss_f32(_mm_sqrt_ss(_mm_dp_ps(xmm_v, xmm_v, 0x71)));
@@ -205,7 +162,6 @@ TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v_01 = _mm_load_pd(vec.data());
     auto xmm_v_23 = _mm_load_pd(vec.data() + 2);
@@ -217,7 +173,6 @@ TM_INLINE auto kernel_length_vec3(const Vec3Buffer<T>& vec) -> T {
 
 template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v = _mm_load_ps(vec.data());
     auto xmm_sums = _mm_dp_ps(xmm_v, xmm_v, 0x7f);
@@ -228,7 +183,6 @@ TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
 
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     // Implementation based on this post: https://bit.ly/3FyZF0n
     auto xmm_v_01 = _mm_load_pd(vec.data());
     auto xmm_v_23 = _mm_load_pd(vec.data() + 2);
@@ -244,7 +198,6 @@ TM_INLINE auto kernel_normalize_in_place_vec3(Vec3Buffer<T>& vec) -> void {
 template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0x71);
@@ -254,7 +207,6 @@ TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
                                const Vec3Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     auto xmm_lhs_01 = _mm_load_pd(lhs.data());
     auto xmm_lhs_23 = _mm_load_pd(lhs.data() + 2);
     auto xmm_rhs_01 = _mm_load_pd(rhs.data());
@@ -267,7 +219,6 @@ TM_INLINE auto kernel_dot_vec3(const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                  const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F32_SSE<T>();
     // Implementation adapted from @ian_mallett (https://bit.ly/3lu6pVe)
     // Recall that the dot product of two 3d-vectors a and b given by:
     // a = {a[0], a[1], a[2], a[3]=0}, b = {b[0], b[1], b[2], b[3]=0}
@@ -301,7 +252,6 @@ TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
 template <typename T, SFINAE_VEC3_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_cross_vec3(Vec3Buffer<T>& dst, const Vec3Buffer<T>& lhs,
                                  const Vec3Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC3_F64_SSE<T>();
     // @todo(wilbert): so far I can't find a way that might be better than
     // the scalar implementation (besides it might be vectorized by O3)
     dst[0] = lhs[1] * rhs[2] - lhs[2] * rhs[1];

--- a/include/tinymath/impl/vec4_t_avx_impl.hpp
+++ b/include/tinymath/impl/vec4_t_avx_impl.hpp
@@ -31,38 +31,6 @@ template <typename T>
 using Vec4Buffer = typename Vector4<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC4_F32_AVX() -> int {
-    static_assert(std::is_same<float, T>::value, "Must be using f32");
-    static_assert(Vector4<T>::BUFFER_SIZE == 4,
-                  "Must be using 4xf32 as aligned buffer");
-    static_assert(Vector4<T>::VECTOR_NDIM == 4,
-                  "Must be using 3xf32 for the elements of the vector");
-    static_assert(
-        sizeof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC4_F64_AVX() -> int {
-    static_assert(std::is_same<double, T>::value, "Must be using f64");
-    static_assert(Vector4<T>::BUFFER_SIZE == 4,
-                  "Must be using 4xf64 as aligned buffer");
-    static_assert(Vector4<T>::VECTOR_NDIM == 4,
-                  "Must be using 3xf64 for the elements of the vector");
-    static_assert(
-        sizeof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_VEC4_F32_AVX_GUARD =
     typename std::enable_if<CpuHasAVX<T>::value && IsFloat32<T>::value>::type*;
 
@@ -73,7 +41,6 @@ using SFINAE_VEC4_F64_AVX_GUARD =
 template <typename T, SFINAE_VEC4_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F32_AVX<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
@@ -83,7 +50,6 @@ TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F64_AVX<T>();
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_add_pd(ymm_lhs, ymm_rhs);
@@ -93,7 +59,6 @@ TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F32_AVX<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
@@ -103,7 +68,6 @@ TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F64_AVX<T>();
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_result = _mm256_sub_pd(ymm_lhs, ymm_rhs);
@@ -113,7 +77,6 @@ TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec4(Vec4Buffer<T>& dst, T scale,
                                  const Vec4Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F32_AVX<T>();
     auto xmm_scale = _mm_set1_ps(scale);
     auto xmm_vector = _mm_load_ps(vec.data());
     auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
@@ -123,7 +86,6 @@ TM_INLINE auto kernel_scale_vec4(Vec4Buffer<T>& dst, T scale,
 template <typename T, SFINAE_VEC4_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec4(Vec4Buffer<T>& dst, T scale,
                                  const Vec4Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F64_AVX<T>();
     auto ymm_scale = _mm256_set1_pd(scale);
     auto ymm_vector = _mm256_load_pd(vec.data());
     auto ymm_result = _mm256_mul_pd(ymm_scale, ymm_vector);
@@ -134,7 +96,6 @@ template <typename T, SFINAE_VEC4_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec4(Vec4Buffer<T>& dst,
                                     const Vec4Buffer<T>& lhs,
                                     const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F32_AVX<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     _mm_store_ps(dst.data(), _mm_mul_ps(xmm_lhs, xmm_rhs));
@@ -144,7 +105,6 @@ template <typename T, SFINAE_VEC4_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec4(Vec4Buffer<T>& dst,
                                     const Vec4Buffer<T>& lhs,
                                     const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F64_AVX<T>();
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     _mm256_store_pd(dst.data(), _mm256_mul_pd(ymm_lhs, ymm_rhs));
@@ -153,7 +113,6 @@ TM_INLINE auto kernel_hadamard_vec4(Vec4Buffer<T>& dst,
 template <typename T, SFINAE_VEC4_F32_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC4_F32_AVX<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0xf1);
@@ -163,7 +122,6 @@ TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F64_AVX_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC4_F64_AVX<T>();
     auto ymm_lhs = _mm256_load_pd(lhs.data());
     auto ymm_rhs = _mm256_load_pd(rhs.data());
     auto ymm_prod = _mm256_mul_pd(ymm_lhs, ymm_rhs);

--- a/include/tinymath/impl/vec4_t_scalar_impl.hpp
+++ b/include/tinymath/impl/vec4_t_scalar_impl.hpp
@@ -10,28 +10,12 @@ template <typename T>
 using Vec4Buffer = typename Vector4<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC4_SCALAR() -> int {
-    static_assert(Vector4<T>::BUFFER_SIZE == 4,
-                  "Must use 4 elements for the internal buffer");
-    static_assert(Vector4<T>::VECTOR_NDIM == 4,
-                  "Must use 4 elements for the vector elements");
-    static_assert(
-        sizeof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_VEC4_SCALAR_GUARD =
     typename std::enable_if<IsScalar<T>::value>::type*;
 
 template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_SCALAR<T>();
     for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] + rhs[i];
     }
@@ -40,7 +24,6 @@ TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_SCALAR<T>();
     for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] - rhs[i];
     }
@@ -49,7 +32,6 @@ TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec4(Vec4Buffer<T>& dst, T scale,
                                  const Vec4Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC4_SCALAR<T>();
     for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         dst[i] = scale * vec[i];
     }
@@ -59,7 +41,6 @@ template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec4(Vec4Buffer<T>& dst,
                                     const Vec4Buffer<T>& lhs,
                                     const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_SCALAR<T>();
     for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         dst[i] = lhs[i] * rhs[i];
     }
@@ -68,7 +49,6 @@ TM_INLINE auto kernel_hadamard_vec4(Vec4Buffer<T>& dst,
 template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC4_SCALAR<T>();
     T accum = static_cast<T>(0.0);
     for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         accum += lhs[i] * rhs[i];
@@ -79,7 +59,6 @@ TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_SCALAR_GUARD<T> = nullptr>
 TM_INLINE auto kernel_compare_eq_vec4(const Vec4Buffer<T>& lhs,
                                       const Vec4Buffer<T>& rhs) -> bool {
-    COMPILE_TIME_CHECKS_VEC4_SCALAR<T>();
     for (int32_t i = 0; i < Vector4<T>::VECTOR_NDIM; ++i) {
         if (std::abs(lhs[i] - rhs[i]) >= tiny::math::EPS<T>) {
             return false;

--- a/include/tinymath/impl/vec4_t_sse_impl.hpp
+++ b/include/tinymath/impl/vec4_t_sse_impl.hpp
@@ -37,38 +37,6 @@ template <typename T>
 using Vec4Buffer = typename Vector4<T>::BufferType;
 
 template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC4_F32_SSE() -> int {
-    static_assert(std::is_same<float, T>::value, "Must be using f32");
-    static_assert(Vector4<T>::BUFFER_SIZE == 4,
-                  "Must be using 4xf32 as aligned buffer");
-    static_assert(Vector4<T>::VECTOR_NDIM == 4,
-                  "Must be using 3xf32 for the elements of the vector");
-    static_assert(
-        sizeof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
-constexpr auto COMPILE_TIME_CHECKS_VEC4_F64_SSE() -> int {
-    static_assert(std::is_same<double, T>::value, "Must be using f64");
-    static_assert(Vector4<T>::BUFFER_SIZE == 4,
-                  "Must be using 4xf64 as aligned buffer");
-    static_assert(Vector4<T>::VECTOR_NDIM == 4,
-                  "Must be using 3xf64 for the elements of the vector");
-    static_assert(
-        sizeof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must use exactly this many bytes of storage");
-    static_assert(
-        alignof(Vector4<T>) == sizeof(std::array<T, Vector4<T>::BUFFER_SIZE>),
-        "Must be aligned to its corresponding size");
-    return 0;
-}
-
-template <typename T>
 using SFINAE_VEC4_F32_SSE_GUARD =
     typename std::enable_if<CpuHasSSE<T>::value && IsFloat32<T>::value>::type*;
 
@@ -79,7 +47,6 @@ using SFINAE_VEC4_F64_SSE_GUARD =
 template <typename T, SFINAE_VEC4_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F32_SSE<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_add_ps(xmm_lhs, xmm_rhs);
@@ -89,7 +56,6 @@ TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F64_SSE<T>();
     auto xmm_lhs_lo = _mm_load_pd(lhs.data());      // load first two doubles
     auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);  // load the next two doubles
     auto xmm_rhs_lo = _mm_load_pd(rhs.data());
@@ -103,7 +69,6 @@ TM_INLINE auto kernel_add_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F32_SSE<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_result = _mm_sub_ps(xmm_lhs, xmm_rhs);
@@ -113,7 +78,6 @@ TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F64_SSE<T>();
     auto xmm_lhs_lo = _mm_load_pd(lhs.data());
     auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);
     auto xmm_rhs_lo = _mm_load_pd(rhs.data());
@@ -127,7 +91,6 @@ TM_INLINE auto kernel_sub_vec4(Vec4Buffer<T>& dst, const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec4(Vec4Buffer<T>& dst, T scale,
                                  const Vec4Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F32_SSE<T>();
     auto xmm_scale = _mm_set1_ps(scale);
     auto xmm_vector = _mm_load_ps(vec.data());
     auto xmm_result = _mm_mul_ps(xmm_scale, xmm_vector);
@@ -137,7 +100,6 @@ TM_INLINE auto kernel_scale_vec4(Vec4Buffer<T>& dst, T scale,
 template <typename T, SFINAE_VEC4_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_scale_vec4(Vec4Buffer<T>& dst, T scale,
                                  const Vec4Buffer<T>& vec) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F64_SSE<T>();
     auto xmm_scale = _mm_set1_pd(scale);
     auto xmm_vector_lo = _mm_load_pd(vec.data());
     auto xmm_vector_hi = _mm_load_pd(vec.data() + 2);
@@ -151,7 +113,6 @@ template <typename T, SFINAE_VEC4_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec4(Vec4Buffer<T>& dst,
                                     const Vec4Buffer<T>& lhs,
                                     const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F32_SSE<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     _mm_store_ps(dst.data(), _mm_mul_ps(xmm_lhs, xmm_rhs));
@@ -161,7 +122,6 @@ template <typename T, SFINAE_VEC4_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_hadamard_vec4(Vec4Buffer<T>& dst,
                                     const Vec4Buffer<T>& lhs,
                                     const Vec4Buffer<T>& rhs) -> void {
-    COMPILE_TIME_CHECKS_VEC4_F64_SSE<T>();
     auto xmm_lhs_lo = _mm_load_pd(lhs.data());
     auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);
     auto xmm_rhs_lo = _mm_load_pd(rhs.data());
@@ -173,7 +133,6 @@ TM_INLINE auto kernel_hadamard_vec4(Vec4Buffer<T>& dst,
 template <typename T, SFINAE_VEC4_F32_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC4_F32_SSE<T>();
     auto xmm_lhs = _mm_load_ps(lhs.data());
     auto xmm_rhs = _mm_load_ps(rhs.data());
     auto xmm_cond_prod = _mm_dp_ps(xmm_lhs, xmm_rhs, 0xf1);
@@ -183,7 +142,6 @@ TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
 template <typename T, SFINAE_VEC4_F64_SSE_GUARD<T> = nullptr>
 TM_INLINE auto kernel_dot_vec4(const Vec4Buffer<T>& lhs,
                                const Vec4Buffer<T>& rhs) -> T {
-    COMPILE_TIME_CHECKS_VEC4_F64_SSE<T>();
     auto xmm_lhs_lo = _mm_load_pd(lhs.data());
     auto xmm_lhs_hi = _mm_load_pd(lhs.data() + 2);
     auto xmm_rhs_lo = _mm_load_pd(rhs.data());

--- a/python/tinymath/bindings/CMakeLists.txt
+++ b/python/tinymath/bindings/CMakeLists.txt
@@ -3,14 +3,18 @@
 # ~~~
 
 if(NOT TINYMATH_BUILD_PYTHON_BINDINGS)
-  tmMessage("Bindings are not required for the current build" LOG_LEVEL TRACE)
+  loco_message("Bindings are not required for the current build" LOG_LEVEL
+               TRACE)
   return()
 endif()
 
 if(NOT TARGET tinymath::tinymath)
-  tmMessage("Bindings require the tinymath::tinymath target" LOG_LEVEL WARNING)
+  loco_message("Bindings require the tinymath::tinymath target" LOG_LEVEL
+               WARNING)
   return()
 endif()
 
-pybind11_add_module(tinymath_py ${CMAKE_CURRENT_SOURCE_DIR}/bindings_py.cpp)
-target_link_libraries(tinymath_py PRIVATE tinymath::tinymath)
+# ~~~
+# pybind11_add_module(tinymath_py ${CMAKE_CURRENT_SOURCE_DIR}/bindings_py.cpp)
+# target_link_libraries(tinymath_py PRIVATE tinymath::tinymath)
+# ~~~

--- a/scripts/setup_dependencies.sh
+++ b/scripts/setup_dependencies.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-## grab pybind11 from master branch
-echo "Setting up dependency: pybind11"
-git clone https://github.com/pybind/pybind11.git ext/pybind11

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -6,8 +6,8 @@ if(NOT TINYMATH_BUILD_TESTS)
 endif()
 
 if((NOT TARGET tinymath::tinymath) OR (NOT TARGET Catch2::Catch2))
-  tmMessage(
-    "Unittests require both tinymath::tinymath and Catch2::Catch2 targets"
+  loco_message(
+    "Unittests require both [tinymath::tinymath] and [Catch2::Catch2] targets"
     LOG_LEVEL WARNING)
   return()
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,53 +1,56 @@
 # ~~~
 # CMake configuration for third-party dependencies.
 #
+# Dependencies:
+# * pybind11
+# * catch2
+#
 # Based on the superbuild script by jeffamstutz for ospray
 # https://github.com/jeffamstutz/superbuild_ospray/blob/main/macros.cmake
 # ~~~
 
 if(NOT TINYMATH_IS_ROOT_PROJECT)
-  tmMessage("Third-party deps. should be handled by root" LOG_LEVEL TRACE)
   return()
 endif()
 
-if(TINYMATH_BUILD_PYTHON_BINDINGS)
-  # cmake-format: off
-  tmConfigureGitDependency(
-      TARGET pybind11
-      REPO https://github.com/pybind/pybind11.git
-      TAG v2.9.1
-      BUILD_MODE ${CMAKE_BUILD_TYPE}
-      BUILD_ARGS
-        -DPYBIND11_TEST=OFF)
-  # cmake-format: on
+# cmake-format: off
 
-  if(NOT pybind11_FOUND)
-    tmMessage("Requested Python bindings, but couldn't find Pybind11 :("
-              LOG_LEVEL WARNING)
-    set(TINYMATH_BUILD_PYTHON_BINDINGS
-        OFF
-        PARENT_SCOPE)
-  endif()
+# ------------------------------------------------------------------------------
+# Pybind11 is used for generating Python bindings for this project's C++ API.
+# Notice that we're using a forked version in which usage of unique-ptr is
+# allowed, as we use this functionality in some other parent projects
+# ------------------------------------------------------------------------------
+loco_configure_git_dependency(
+    TARGET pybind11
+    REPO https://github.com/pybind/pybind11.git
+    TAG v2.9.1
+    BUILD_MODE ${CMAKE_BUILD_TYPE}
+    BUILD_ARGS
+      -DPYBIND11_TEST=OFF
+    DISCARD_UNLESS TINYMATH_BUILD_PYTHON_BINDINGS)
+
+if(NOT pybind11_FOUND)
+  loco_message("Requested Python bindings, but couldn't find Pybind11 :("
+               LOG_LEVEL FATAL_ERROR)
 endif()
 
-if(TINYMATH_BUILD_TESTS)
-  # cmake-format: off
-  tmConfigureGitDependency(
-      TARGET catch2
-      REPO https://github.com/catchorg/Catch2.git
-      TAG v2.13.8
-      BUILD_MODE ${CMAKE_BUILD_TYPE}
-      BUILD_ARGS
-        -DCATCH_INSTALL_DOCS=OFF
-        -DCATCH_INSTALL_EXTRAS=OFF
-        -DCATCH_DEVELOPMENT_BUILD=OFF)
-  # cmake-format: on
+# ------------------------------------------------------------------------------
+# Catch2 is used for generating unittests for our C++ codebase
+# ------------------------------------------------------------------------------
+loco_configure_git_dependency(
+    TARGET catch2
+    REPO https://github.com/catchorg/Catch2.git
+    TAG v2.13.8
+    BUILD_TYPE ${CMAKE_BUILD_TYPE}
+    BUILD_ARGS
+      -DCATCH_INSTALL_DOCS=OFF
+      -DCATCH_INSTALL_EXTRAS=OFF
+      -DCATCH_DEVELOPMENT_BUILD=OFF
+    DISCARD_UNLESS TINYMATH_BUILD_TESTS)
 
-  if(NOT TARGET Catch2::Catch2)
-    tmMessage("Requested Catch2 support, but couldn't find Catch2 :(" LOG_LEVEL
-              WARNING)
-    set(TINYMATH_BUILD_TESTS
-        OFF
-        PARENT_SCOPE)
-  endif()
+if(NOT TARGET Catch2::Catch2)
+  loco_message("Requested Catch2 support, but couldn't find Catch2 :("
+               LOG_LEVEL FATAL_ERROR)
 endif()
+
+# cmake-format: on


### PR DESCRIPTION
# Description

This PR handles the integration of the repo [`loco_cmake`][0], which allows us to remove the duplicated `.cmake` scripts in the `/cmake` folder. `loco_cmake` will replace the duplicated `/cmake` scripts in various of our projects, so it will be a common dependency which has to be integrated (as in this case)


[0]: <https://github.com/wpumacay/loco_cmake> (loco-cmake-repo)